### PR TITLE
Design auth handling

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Created by https://www.toptal.com/developers/gitignore/api/osx,python,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=osx,python,windows,linux
 
+# JetBrains 
+.idea
+
+# VSCode
+.vscode
+
+
 ### Linux ###
 *~
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,21 @@
+# 1. Record architecture decisions
+
+Date: 2020-12-17
+
+## Status
+
+Proposed
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use a modified version of Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions). ADR documents that are specific to this project will be stored in the `docs/adr` directory within this repository. Instead of using the "deprecated" and "superseded" status value, we will move ADRs that are no longer applicable into the `docs/adr/archive` directory in this repository.
+
+## Consequences
+
+See Michael Nygard's article, linked above, for general consequences related to using ADR documents. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
+
+Moving deprecated and/or superseded decisions into a separate directory will meant that developers can see all currently relevant decisions in a single place, but will need to navigate to a separate location to see the full history of architectural decisions.

--- a/docs/adr/0002-resolving-api-keys.md
+++ b/docs/adr/0002-resolving-api-keys.md
@@ -28,7 +28,7 @@ us from storing this additional information.
 The Python client will resolve the API key to be used in a request in the following order:
 
 1) Passing an `api_key` argument directly to the method
-2) Setting an `ML_HUB_API_KEY` environment variable
+2) Setting an `MLHUB_API_KEY` environment variable
 3) Passing a `profile` argument directly to the method. This will read the API key from the given profile (see below for details)
 4) Setting an `MLHUB_PROFILE` environment variable. This will read the API key from the given profile (see below for details)
 5) Using the API from the `default` profile

--- a/docs/adr/0002-resolving-api-keys.md
+++ b/docs/adr/0002-resolving-api-keys.md
@@ -8,15 +8,20 @@ Proposed
 
 ## Context
 
-We need a convenient system for managing API keys used by the Python client. This system should give the user multiple options for providing an API key to be used when making a request to the API. These options should include:
+We need a convenient system for managing API keys used by the Python client. This system should give the user multiple options for 
+providing an API key to be used when making a request to the API. These options should include:
 
 * Storing API keys on the users system
 * Reading an API key from the environment
 * Passing an API key directly to the API request methods
 
-Users may have multiple valid API keys associated with their account at any given time. The system for storing API keys on the users system must accomodate this and provide a clear, determistic way of resolving an API key for a given project.
+Users may have multiple valid API keys associated with their account at any given time. The system for storing API keys on the user's 
+system must accommodate this and provide a clear, deterministic way of resolving an API key for a given project.
 
-We anticipate the need to store other data related to MLHub for uses unrelated to authentication. For instance, we may have a need to track the progress of downloads so that they can be resumed if interrupted, or we may want to specify a base URL in a config file so that developers can test against the staging environment. The method that we choose for storing API keys on the users system must not preclude us from storing this additional information. 
+We anticipate the need to store other data related to MLHub for uses unrelated to authentication. For instance, we may have a need to 
+track the progress of downloads so that they can be resumed if interrupted, or we may want to specify a base URL in a config file so that 
+developers can test against the staging environment. The method that we choose for storing API keys on the user's system must not preclude 
+us from storing this additional information. 
 
 ## Decision
 
@@ -24,13 +29,24 @@ The Python client will resolve the API key to be used in a request in the follow
 
 1) Passing an `api_key` argument directly to the method
 2) Setting an `ML_HUB_API_KEY` environment variable
-3) Reading the `auth.api_key` value from a `.mlhub/config.ini` file (relative to the current working directory)
-4) Reading the `auth.api_key` value from a `.mlhub/config.ini` file (relative the users's home directory)
+3) Passing a `profile` argument directly to the method. This will read the API key from the given profile (see below for details)
+4) Setting an `MLHUB_PROFILE` environment variable. This will read the API key from the given profile (see below for details)
+5) Using the API from the `default` profile
+
+Profiles will be stored in a `.mlhub/profiles` file in the user's home directory. This file will be an INI file containing at least a 
+`[default]` section with an `api_key` value. The file may contain other sections corresponding to named profiles. Any `profile` argument 
+passed to a method must correspond to one of these section names, or it will raise an exception.
 
 ## Consequences
 
-If the user has a single API key, they will be able to save it in a `.mlhub/config.ini` file in their user directory and all projects that access the API will use that key. If the user have a need for project-specific API keys, they can specify those in `.mlhub/config.ini` files within their project directories. If the user needs finer-grained control over the API key being used, they can specify it as an environment variable or as an argument to the request method.
+If the user has a single API key, they will be able to save it in a `default` profile in a `.mlhub/profiles` file in their user directory 
+and all projects that access the API will use that key. If the user have a need for project-specific API keys, they can specify those in 
+other named profiles (e.g. `some-project`), in the same `.mlhub/profiles` file. If the user needs finer-grained control over the API key 
+being used, they can specify it as an environment variable or as an argument to the request method.
 
-Users will need to have knowledge or guidance on the syntax used in the `.mlhub/config.ini` file in order to configure it correctly. They will also need guidance on how to generate and/or find their API key outside of the Python client.
+Users will need knowledge or guidance on the syntax used in the `.mlhub/profiles` file in order to configure it correctly. They 
+will also need guidance on how to generate and/or find their API key outside the Python client.
 
-Using a `.ini` file means that we can use the `configparser` module from the Python standard library, removing the need for an additional dependency like (e.g. `toml`). Additional configuration (e.g. base URL) can be added to the config file and additional files can be written to the `.mlhub` directory without affecting the authentication flow.
+Using an INI file means that we can use the `configparser` module from the Python standard library, removing the need for an additional 
+dependency like (e.g. `toml`). Additional configuration (e.g. base URL) can be added to the config file and additional files can be written 
+to the `.mlhub` directory without affecting the authentication flow.

--- a/docs/adr/0002-resolving-api-keys.md
+++ b/docs/adr/0002-resolving-api-keys.md
@@ -1,0 +1,36 @@
+# 2. Resolving API key
+
+Date: 2020-12-17
+
+## Status
+
+Proposed
+
+## Context
+
+We need a convenient system for managing API keys used by the Python client. This system should give the user multiple options for providing an API key to be used when making a request to the API. These options should include:
+
+* Storing API keys on the users system
+* Reading an API key from the environment
+* Passing an API key directly to the API request methods
+
+Users may have multiple valid API keys associated with their account at any given time. The system for storing API keys on the users system must accomodate this and provide a clear, determistic way of resolving an API key for a given project.
+
+We anticipate the need to store other data related to MLHub for uses unrelated to authentication. For instance, we may have a need to track the progress of downloads so that they can be resumed if interrupted, or we may want to specify a base URL in a config file so that developers can test against the staging environment. The method that we choose for storing API keys on the users system must not preclude us from storing this additional information. 
+
+## Decision
+
+The Python client will resolve the API key to be used in a request in the following order:
+
+1) Passing an `api_key` argument directly to the method
+2) Setting an `ML_HUB_API_KEY` environment variable
+3) Reading the `auth.api_key` value from a `.mlhub/config.ini` file (relative to the current working directory)
+4) Reading the `auth.api_key` value from a `.mlhub/config.ini` file (relative the users's home directory)
+
+## Consequences
+
+If the user has a single API key, they will be able to save it in a `.mlhub/config.ini` file in their user directory and all projects that access the API will use that key. If the user have a need for project-specific API keys, they can specify those in `.mlhub/config.ini` files within their project directories. If the user needs finer-grained control over the API key being used, they can specify it as an environment variable or as an argument to the request method.
+
+Users will need to have knowledge or guidance on the syntax used in the `.mlhub/config.ini` file in order to configure it correctly. They will also need guidance on how to generate and/or find their API key outside of the Python client.
+
+Using a `.ini` file means that we can use the `configparser` module from the Python standard library, removing the need for an additional dependency like (e.g. `toml`). Additional configuration (e.g. base URL) can be added to the config file and additional files can be written to the `.mlhub` directory without affecting the authentication flow.


### PR DESCRIPTION
Adds the `docs/adr/0002-resolving-api-keys.md` ADR describing the design for how we plan to resolve the API key that should be used in a given request.

The high-level summary is that we plan to try to resolve the key using the following strategies (in order):

1) An `api_key` argument passed directly to the request
2) An `MLHUB_API_KEY` variable found in the environment
3) A `.mlhub/config.ini` file with an `auth.api_key` value found in the current working directory
4) A `.mlhub/config.ini` file with an `auth.api_key` value found in the user's home directory

**UPDATE:** The location of the ADR is open to change based on how we decide to handle ADR documents across all of our systems. I'm planning on updating that location based on the outcome of those decisions. This PR is mostly focused on getting feedback on the content of the document.