### PR TITLE
Add unit tests to CI/CD

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -11,11 +11,6 @@ on:
       - pyproject.toml
       - 'test/**'
 
-  # For testing...
-  push:
-    branches:
-      - ci-testing
-
 jobs:
   lint:
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,0 +1,98 @@
+name: Run unit tests on supported Python versions
+
+on:
+  pull_request:
+    branches:
+      - master
+      - dev
+    paths:
+      - 'radiant_mlhub/**'
+      - setup.py
+      - pyproject.toml
+      - 'test/**'
+
+  # For testing...
+  push:
+    branches:
+      - ci-testing
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install linter dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8~=3.8.0 mypy~=0.790
+
+      - name: Run flake8 and mypy
+        run: |
+          flake8
+          mypy radiant_mlhub
+
+  test:
+
+    strategy:
+      matrix:
+        python-version: [ 3.6, 3.7, 3.8 ]
+        os:
+          - ubuntu-latest
+          # Since these runners cost 10x and 2x as much as ubuntu, respectively, we may
+          # want to only run these against release branches or some other last check before
+          # publishing
+          # - macos-latest
+          # - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python-version }}
+
+      # Caches the pip install directory based on the OS
+      - name: Cache test dependencies (Linux)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+
+      - name: Cache test dependencies (MacOS)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+
+      - name: Cache test dependencies (Windows)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+
+      # We run this every time because an if statement that checks each cache hit would be complicated
+      #  and the step should take very little time if a cache was found
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+
+      - name: Run tests
+        run: |
+          pip install .
+          pytest test

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Run unit tests on supported Python versions
+name: Unit tests
 
 on:
   pull_request:
@@ -12,6 +12,7 @@ on:
       - 'test/**'
 
 jobs:
+
   lint:
 
     runs-on: ubuntu-latest
@@ -36,16 +37,19 @@ jobs:
 
   test:
 
+    # Only runs the Windows and MacOS tests if the PR is against master
+    if: github.base_ref == 'master' || matrix.os == 'ubuntu-latest'
+
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
         os:
           - ubuntu-latest
-          # Since these runners cost 10x and 2x as much as ubuntu, respectively, we may
-          # want to only run these against release branches or some other last check before
-          # publishing
-          # - macos-latest
-          # - windows-latest
+          - macos-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Radiant MLHub Python Client
+
+![Unit tests](https://github.com/radiantearth/radiant-mlhub/workflows/Unit%20tests/badge.svg)

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -72,7 +72,8 @@ class TestResolveAPIKeys:
     def test_no_profiles_file(self, tmp_path, monkeypatch):
         # Ensure there is no profiles file
         config_file = tmp_path / '.mlhub' / 'profiles'
-        config_file.unlink(missing_ok=True)
+        if config_file.exists():
+            config_file.unlink()
 
         # Monkeypatch the user's home directory to be the temp directory
         monkeypatch.setenv('HOME', str(tmp_path))
@@ -104,7 +105,8 @@ class TestResolveAPIKeys:
 
         # Ensure we don't have a profiles file
         config_file = tmp_path / '.mlhub' / 'profiles'
-        config_file.unlink(missing_ok=True)
+        if config_file.exists():
+            config_file.unlink()
 
         with pytest.raises(ValueError) as excinfo:
             get_session()


### PR DESCRIPTION
Adds a new GitHub workflow for running unit tests using `pytest` and running the `flake8` code linter. 

The workflow runs the unit tests on Python versions 3.6, 3.7, and 3.8 using the `ubuntu-latest` runner for all PRs against `dev` and `master`. Any PRs against `master` will also run tests on the Python versions above on the `windows-latest` and `macos-latest` runners (these runners are more expensive than Ubuntu, which is why I've restricted them to just the `master` PRs).