### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
   test:
 
     # Only runs the Windows and MacOS tests if the PR is against master
-    if: github.base_ref == 'master' || matrix.os == 'ubuntu-latest'
+    if: github.base_ref == 'master' || startsWith(runner.os, 'Linux')
 
     strategy:
       matrix:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -2,7 +2,7 @@ name: Unit tests
 
 on:
 
-  push: &trigger_config
+  push:
 
     branches:
       - master
@@ -15,7 +15,16 @@ on:
       - 'test/**'
 
   pull_request:
-    <<: *trigger_config
+
+    branches:
+      - master
+      - dev
+
+    paths:
+      - 'radiant_mlhub/**'
+      - setup.py
+      - pyproject.toml
+      - 'test/**'
 
 jobs:
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,15 +1,21 @@
 name: Unit tests
 
 on:
-  pull_request:
+
+  push: &trigger_config
+
     branches:
       - master
       - dev
+
     paths:
       - 'radiant_mlhub/**'
       - setup.py
       - pyproject.toml
       - 'test/**'
+
+  pull_request:
+    <<: *trigger_config
 
 jobs:
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -50,10 +50,7 @@ jobs:
           flake8
           mypy radiant_mlhub
 
-  test:
-
-    # Only runs the Windows and MacOS tests if the PR is against master
-    if: github.base_ref == 'master' || startsWith(runner.os, 'Linux')
+  test_linux:
 
     strategy:
       matrix:
@@ -62,9 +59,7 @@ jobs:
           - 3.7
           - 3.8
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-18.04
 
     runs-on: ${{ matrix.os }}
 
@@ -83,21 +78,81 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Cache test dependencies (MacOS)
         uses: actions/cache@v2
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Cache test dependencies (Windows)
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Windows')
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+
+      # We run this every time because an if statement that checks each cache hit would be complicated
+      #  and the step should take very little time if a cache was found
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+
+      - name: Run tests
+        run: |
+          pip install .
+          pytest test
+
+  test_mac_windows:
+
+    # Only run this for PRs against master and pushes to master
+    if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'master')
+
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
+        os:
+          - macos-10.15
+          - windows-2019
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python-version }}
+
+      # Caches the pip install directory based on the OS
+      - name: Cache test dependencies (Linux)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+
+      - name: Cache test dependencies (MacOS)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+
+      - name: Cache test dependencies (Windows)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
 
       # We run this every time because an if statement that checks each cache hit would be complicated
       #  and the step should take very little time if a cache was found

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Radiant MLHub Python Client
 
-![Unit tests](https://github.com/radiantearth/radiant-mlhub/workflows/Unit%20tests/badge.svg)
+[![Unit tests](https://github.com/radiantearth/radiant-mlhub/workflows/Unit%20tests/badge.svg)](https://github.com/radiantearth/radiant-mlhub/actions)
+[![Documentation](https://readthedocs.org/projects/radiant-mlhub/badge/)](https://radiant-mlhub.readthedocs.io/en/latest/)
+[![PyPI version](https://badge.fury.io/py/radiant-mlhub.svg)](https://pypi.org/project/radiant-mlhub/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/radiant-mlhub)
+
+*A Python client for the [Radiant MLHub API](https://mlhub.earth/).*
+
+## Documentation
+
+API reference and Getting Started guides are available on [Read the Docs](https://radiant-mlhub.readthedocs.io/en/latest/).
+
+## Design Decisions
+
+Major architectural and design decisions are documented using [Architectural Design Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) stored in the [`docs/adr`](./docs/adr) directory.
+

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -20,7 +20,8 @@ class TestResolveAPIKeys:
         config['blank-profile'] = {}
 
         # Monkeypatch the user's home directory to be the temp directory
-        monkeypatch.setenv('HOME', str(tmp_path))
+        monkeypatch.setenv('HOME', str(tmp_path))  # Linux/Unix
+        monkeypatch.setenv('USERPROFILE', str(tmp_path))  # Windows
 
         # Create .mlhub directory and config file
         mlhub_dir = tmp_path / '.mlhub'
@@ -48,7 +49,7 @@ class TestResolveAPIKeys:
         session = get_session()
         assert session.params.get('key') == 'defaultapikey'
 
-    def test_api_key_from_named_profile(self, tmp_path, monkeypatch, config_content):
+    def test_api_key_from_named_profile(self, tmp_path, config_content):
         """The API key from the given profile in ~/.mlhub/profiles is stored on the session."""
         session = get_session(profile='other-profile')
         assert session.params.get('key') == 'otherapikey'


### PR DESCRIPTION
Runs the unit tests for pushes to `master` and `dev` in addition to PRs against those branches, and adds some reference links and badges to the main README.

**UPDATE:** I also separated the jobs for running tests on Windows and Mac from the test on Linux. It turns out we can't examine the `matrix` context in a job-level `if` statement since it is defined at the same level as `strategy.matrix`, so this seemed like the best way to ensure that we only run those jobs for PRs and pushes to `master`. 

The Windows test is failing due to an issue with monkeypatching the user's home directory in the test. I'll work on a fix for that, but I also don't want to burn too much of our compute time on that, so I may not bother running that job again until we're closer to a release.