### PR TITLE
Update auth error handling and docs

### DIFF
--- a/docs/source/api/radiant_mlhub.rst
+++ b/docs/source/api/radiant_mlhub.rst
@@ -12,6 +12,14 @@ radiant\_mlhub.client module
    :undoc-members:
    :show-inheritance:
 
+radiant\_mlhub.exceptions module
+--------------------------------
+
+.. automodule:: radiant_mlhub.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 radiant\_mlhub.models module
 ----------------------------
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,7 +1,7 @@
 Authentication
 ==============
 
-The MLHub API uses API keys to authenticate users. These keys must be passed as a `key` query parameter in any request made to the API.
+The MLHub API uses API keys to authenticate users. These keys must be passed as a ``key`` query parameter in any request made to the API.
 Anyone can register for an API key by going to `https://dashboard.mlhub.earth <https://dashboard.mlhub.earth>`_ and creating an account.
 Once you have logged into your account, go to `http://dashboard.mlhub.earth/api-keys <http://dashboard.mlhub.earth/api-keys>`_ to create
 API keys.
@@ -18,9 +18,13 @@ The best way to add your API key to requests is to create a :class:`~radiant_mlh
     >>> session = get_session()
     >>> r = session.get(...)
 
-You can associated an API key with a session in a number of ways: programmatically via an instantiation argument, using environment
-variables, or using a named profile. The :class:`~radiant_mlhub.session.Session` resolves an API key by trying each of the following, in
-order:
+You can associated an API key with a session in a number of ways:
+
+* programmatically via an instantiation argument
+* using environment variables
+* using a named profile
+
+The :class:`~radiant_mlhub.session.Session` resolves an API key by trying each of the following (in this order):
 
 1) Use an ``api_key`` argument provided during instantiation
 
@@ -55,12 +59,16 @@ order:
 
        >>> session = get_session()
 
-*If none of the above strategies results in a valid API key, then an exception is raised.*
+*If none of the above strategies results in a valid API key, then an* :exc:`~radiant_mlhub.exceptions.APIKeyNotFound` *exception is raised.*
 
-The :class:`radiant_mlhub.session.Session` instance inherits from :class:`requests.Session` and adds 2 conveniences to a typical session:
+The :class:`radiant_mlhub.session.Session` instance inherits from :class:`requests.Session` and adds a few conveniences to a typical
+session:
 
-1) Injects API key into query params
-2) Prepends the MLHub root URL (``https://api.radiant.earth/mlhub/v1/``) to request paths
+* Adds the API key as a ``key`` query parameter
+* Adds an ``Accept: application/json`` header
+* Adds a ``User-Agent`` header that contains the package name and version, plus basic system information like the the OS name
+* Prepends the MLHub root URL (``https://api.radiant.earth/mlhub/v1/``) to any request paths without a domain
+* Raises a :exc:`radiant_mlhub.exceptions.AuthenticationError` for ``401 (UNAUTHORIZED)`` responses
 
 Using Profiles
 ++++++++++++++

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -18,7 +18,7 @@ The best way to add your API key to requests is to create a :class:`~radiant_mlh
     >>> session = get_session()
     >>> r = session.get(...)
 
-You can associated an API key with a session in a number of ways:
+You can associate an API key with a session in a number of ways:
 
 * programmatically via an instantiation argument
 * using environment variables

--- a/radiant_mlhub/exceptions.py
+++ b/radiant_mlhub/exceptions.py
@@ -5,3 +5,7 @@ class MLHubException(Exception):
 class AuthenticationError(MLHubException):
     """Raised when the Radiant MLHub API cannot authenticate the request, either because the API key is invalid or expired, or because
     no API key was provided in the request."""
+
+
+class APIKeyNotFound(MLHubException):
+    """Raised when an API key cannot be found using any of the strategies described in the :ref:`Authentication` docs."""

--- a/radiant_mlhub/exceptions.py
+++ b/radiant_mlhub/exceptions.py
@@ -1,0 +1,7 @@
+class MLHubException(Exception):
+    """Base exception class for all Radiant MLHub exceptions"""
+
+
+class AuthenticationError(MLHubException):
+    """Raised when the Radiant MLHub API cannot authenticate the request, either because the API key is invalid or expired, or because
+    no API key was provided in the request."""


### PR DESCRIPTION
Updates the error handling within the `Session` class by:
* raising a new custom `AuthenticationError` exception whenever a `401` response is received
* raising a new custom `APIKeyNotFound` exception when the API key cannot be resolved

Also adds tests for the desired query parameter behavior and updates the Authentication and API docs to be a bit more clear in some areas.