### PR TITLE
Change default branch to main

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
     branches:
-      - master
+      - main
       - dev
 
     paths:
@@ -17,7 +17,7 @@ on:
   pull_request:
 
     branches:
-      - master
+      - main
       - dev
 
     paths:
@@ -109,8 +109,8 @@ jobs:
 
   test_mac_windows:
 
-    # Only run this for PRs against master and pushes to master
-    if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'master')
+    # Only run this for PRs against main and pushes to main
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'push' && github.ref == 'main')
 
     strategy:
       matrix:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. radiant_mlhub documentation master file, created by
+.. radiant_mlhub documentation main file, created by
    sphinx-quickstart on Mon Dec 21 11:38:03 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.


### PR DESCRIPTION
Updates the GitHub Actions workflows to use `main` as the default/main branch. The default branch for the repo has been manually changed to `main` and the ReadTheDocs settings have been adjusted to build the `latest` and `stable` versions of the docs from the `main` branch.