### PR TITLE
CI/Testing Improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,7 @@ exclude =
     .pytest_cache
     .vscode
     .idea
+    .tox
     env
     venv
     docs

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,12 +6,12 @@ on:
     - published
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-publish:
 
-    # Only run the job for releases and PRs against master from release* branches
+    # Only run the job for releases and PRs against main from release* branches
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'pull_request' && startswith(github.ref, 'ref/heads/release'))
@@ -46,7 +46,7 @@ jobs:
         password: ${{ secrets.pypi_password }}
 
     - name: Publish distribution to TestPyPI
-      # Publish to TestPyPi for PRs against master from release branches
+      # Publish to TestPyPi for PRs against main from release branches
       if: (github.event_name == 'pull_request') && startsWith(github.ref, 'refs/heads/release')
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,9 +4,18 @@ on:
   release:
     types:
     - published
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-and-publish:
+
+    # Only run the job for releases and PRs against master from release* branches
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'pull_request' && startswith(github.ref, 'ref/heads/release'))
+
     name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-18.04
     steps:
@@ -30,7 +39,16 @@ jobs:
         --outdir dist/
         .
     - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      # Publish to PyPi for releases
+      if: (github.event_name == 'release') && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_password }}
+
+    - name: Publish distribution to TestPyPI
+      # Publish to TestPyPi for PRs against master from release branches
+      if: (github.event_name == 'pull_request') && startsWith(github.ref, 'refs/heads/release')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -81,12 +81,12 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
-          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_dev.txt') }}
+          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_testing.txt') }}
 
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements_dev.txt
+          pip install -r requirements_testing.txt
 
       - name: Run tests
         run: |
@@ -128,19 +128,19 @@ jobs:
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
-          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_dev.txt') }}
+          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_testing.txt') }}
 
       - name: Cache test dependencies (${{ matrix.os }})
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Windows')
         with:
           path: ~\AppData\Local\pip\Cache
-          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_dev.txt') }}
+          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_testing.txt') }}
 
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements_dev.txt
+          pip install -r requirements_testing.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -81,7 +81,7 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
-          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Install test dependencies
         run: |
@@ -126,14 +126,14 @@ jobs:
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
-          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Cache test dependencies (${{ matrix.os }})
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Windows')
         with:
           path: ~\AppData\Local\pip\Cache
-          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
+          key: unit-tests-${{ matrix.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -13,6 +13,7 @@ on:
       - setup.py
       - pyproject.toml
       - 'test/**'
+      - '.github/workflows/run-unit-tests.yml'
 
   pull_request:
 
@@ -25,6 +26,7 @@ on:
       - setup.py
       - pyproject.toml
       - 'test/**'
+      - '.github/workflows/run-unit-tests.yml'
 
 jobs:
 
@@ -68,35 +70,19 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python-version }}
 
       # Caches the pip install directory based on the OS
-      - name: Cache test dependencies (Linux)
+      - name: Cache test dependencies (${{ matrix.os }})
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
           key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
 
-      - name: Cache test dependencies (MacOS)
-        uses: actions/cache@v2
-        if: startsWith(runner.os, 'macOS')
-        with:
-          path: ~/Library/Caches/pip
-          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
-
-      - name: Cache test dependencies (Windows)
-        uses: actions/cache@v2
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
-
-      # We run this every time because an if statement that checks each cache hit would be complicated
-      #  and the step should take very little time if a cache was found
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
@@ -129,35 +115,26 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python-version }}
 
       # Caches the pip install directory based on the OS
-      - name: Cache test dependencies (Linux)
-        uses: actions/cache@v2
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
-
-      - name: Cache test dependencies (MacOS)
+      - name: Cache test dependencies (${{ matrix.os }})
         uses: actions/cache@v2
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
           key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
 
-      - name: Cache test dependencies (Windows)
+      - name: Cache test dependencies (${{ matrix.os }})
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Windows')
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ matrix.os }}-test-dependencies-${{ hashFiles('requirements_dev.txt') }}
 
-      # We run this every time because an if statement that checks each cache hit would be complicated
-      #  and the step should take very little time if a cache was found
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -96,7 +96,9 @@ jobs:
   test_mac_windows:
 
     # Only run this for PRs against main and pushes to main
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'push' && github.ref == 'main')
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+## Branches
+The `main` branch represents the latest stable version of the `radiant-mlhub` Python client. The `dev` branch 
+is where active feature development takes place. When developing new features, please create a branch off of the 
+`dev` branch (ideally with a `feature-` prefix) and create a PR for that branch against`dev` 
+when it is ready for review. 
+
+To work on a hotfix for bugs affecting the "production" code (code that is part of a released package), please create 
+a branch off of `main` (ideally with a `hotfix-` prefix) and create a PR for that branch against `main` 
+when it is ready for review.
+
+## Tests
+
+This library uses [`pytest`](https://docs.pytest.org/en/stable/) for unit testing, [`flake8`](https://flake8.pycqa.org/en/latest/) 
+for code style checking, and [`mypy`](https://mypy.readthedocs.io/en/stable/) for type checking. You can run the full set of tests 
+as follows (from the project root):
+
+```shell
+> pip install -r requirements_dev.txt
+> pytest
+> flake8
+> mypy radiant_mlhub
+```
+
+## Releases
+
+When the code on the `dev` branch has stabilized, we will cut a new release using the following procedure:
+
+1) Create a `release-<version>` branch from `dev`, where `<version>` is the version to be released
+
+2) [Run `bumpversion`](https://github.com/c4urself/bump2version#usage) to bump the package to the desired 
+   version. 
+   
+   If you are bumping to a "pre-release" version (e.g. `1.0.0-beta.0`) you may need to specify an 
+   explicit `--new-version` option, otherwise just use `patch`, `minor`, or `major` to bump.
+
+3) Test and make any last-minute changes
+
+4) Put in a PR against `main`
+
+   This will trigger the CI to run unit tests and to publish a test package to TestPyPi.
+
+5) Approve and merge into `main`
+
+   Once the PR has been approved, merge into `main`
+
+6) Tag and publish release
+
+   This will trigger the CI to publish the package to PyPi
+
+7) Merge release branch into `dev`
+
+  This ensures that `dev` stays up-to-date with any changes made during the release process (including updating 
+  the package version). There is no need to put in a PR against `dev`, since the changes have already been 
+  approved for `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Development Environment
+
+Install development dependencies:
+
+```shell
+> pip install -r requirements_dev.txt
+```
+
 ## Branches
 The `main` branch represents the latest stable version of the `radiant-mlhub` Python client. The `dev` branch 
 is where active feature development takes place. When developing new features, please create a branch off of the 
@@ -13,15 +21,23 @@ when it is ready for review.
 ## Tests
 
 This library uses [`pytest`](https://docs.pytest.org/en/stable/) for unit testing, [`flake8`](https://flake8.pycqa.org/en/latest/) 
-for code style checking, and [`mypy`](https://mypy.readthedocs.io/en/stable/) for type checking. You can run the full set of tests 
-as follows (from the project root):
+for code style checking, and [`mypy`](https://mypy.readthedocs.io/en/stable/) for type checking. We use [`tox`](https://tox.readthedocs.io/en/latest/examples.html)
+run each of these tools against all supported Python versions.
+
+To run against all supported Python versions in parallel:
 
 ```shell
-> pip install -r requirements_dev.txt
-> pytest
-> flake8
-> mypy radiant_mlhub
+> tox -p
 ```
+
+To run against just Python 3.8:
+
+```shell
+> tox -e py38
+```
+
+*Note that you must have all supported Python versions installed in order to run tests against them. See [`tox-pyenv`](https://pypi.org/project/tox-pyenv/) if you are 
+using `pyenv` to manage your installed Python versions.*  
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ API reference and Getting Started guides are available on [Read the Docs](https:
 
 Major architectural and design decisions are documented using [Architectural Design Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) stored in the [`docs/adr`](./docs/adr) directory.
 
+## Contributing
+
+See the [Contributing](./CONTRIBUTING.md) docs for details on contributing to the project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.tox]
+
+legacy_tox_ini = """
+[tox]
+isolated_build = True
+envlist = py36, py37, py38, py39
+
+[testenv]
+deps = -rrequirements_testing.txt
+commands =
+    pytest
+    flake8
+    mypy radiant_mlhub
+"""

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,3 @@
-pytest~=6.2.1
-requests-mock~=1.8.0
 sphinx~=3.4.0
 sphinx-rtd-theme~=0.5.0
 bump2version~=0.5.8
-flake8~=3.8.0
-mypy~=0.790

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 sphinx~=3.4.0
 sphinx-rtd-theme~=0.5.0
 bump2version~=0.5.8
+tox~=3.21.0

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,0 +1,4 @@
+pytest~=6.2.1
+requests-mock~=1.8.0
+flake8~=3.8.0
+mypy~=0.790


### PR DESCRIPTION
Changes:

* Removes some unused steps in the unit test workflow
* More specific cache key to avoid race conditions/workflow errors

   Some errors were popping up when trying to save the cache because multiple jobs were attempting to write to the same cache key. This updates the keys to be specific to the Python version to avoid this.
* Adds "Contributing" docs

   Includes details on branch naming, releases, and testing
* Use TestPyPi to test packaging and distribution

   Runs a job to publish to TestPyPi for PRs from `release*` branches to `master` so we can verify that the packaging and distribution succeed before we publish the actual release.
* Adds tox configuration

   This isn't used in the CI, but makes it a bit easier to test locally before putting in a PR