### PR TITLE
Add support for scientific extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     },
     install_requires=[
         'requests~=2.25.1',
-        'pystac~=0.5.3',
+        'pystac~=0.5.4',
         'click~=7.1.2'
     ],
     classifiers=[


### PR DESCRIPTION
Bumps the version of `PySTAC` to `0.5.4` to include newly added support for the `scientific` extension. This allows us to access properties like the citation using `PySTAC` methods instead of having to convert to dictionary first.