### PR TITLE
Retry & resume downloads

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -8,3 +8,6 @@ ignore_missing_imports = True
 
 [mypy-tqdm.*]
 ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -128,5 +128,10 @@ method. This is the recommended way of downloading an archive.
     >>> archive_path
     PosixPath('/Users/someuser/Downloads/sn1_AOI_1_RIO.tar.gz')
 
-You can read more about the structure of these archives in `this Medium post
+If a file of the same name already exists, these methods will check whether the downloaded file is complete by comparing its size against the size of the remote
+file. If they are the same size, the download is skipped, otherwise the download will be resumed from the point where it stopped. You can control
+this behavior using the ``if_exists`` argument. Setting this to ``"skip"`` will skip the download for existing files *without* checking for
+completeness (a bit faster since it doesn't require a network request), and setting this to ``"overwrite"`` will overwrite any existing file.
+
+Collection archives are gzipped tarballs. You can read more about the structure of these archives in `this Medium post
 <https://medium.com/radiant-earth-insights/archived-training-dataset-downloads-now-available-on-radiant-mlhub-7eb67daf094e>`_.

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -123,6 +123,13 @@ The :meth:`Dataset.download <radiant_mlhub.models.Dataset.download>` method prov
 the archives for all collections associated with a given dataset. This method downloads the archives for all associated collections
 into the given output directory and returns a list of the paths to these archives.
 
+If a file of the same name already exists for any of the archives, this method will check whether the downloaded file is complete by
+comparing its size against the size of the remote file. If they are the same size, the download is skipped, otherwise the download
+will be resumed from the point where it stopped. You can control this behavior using the ``if_exists`` argument. Setting this to
+``"skip"`` will skip the download for existing files *without* checking for completeness (a bit faster since it doesn't require a
+network request), and setting this to ``"overwrite"`` will overwrite any existing file.
+
+
 .. code-block:: python
 
     >>> dataset = Collection.fetch('bigearthnet_v1')
@@ -130,5 +137,5 @@ into the given output directory and returns a list of the paths to these archive
     >>> len(archive_paths)
     2
 
-You can read more about the structure of these archives in `this Medium post
+Collection archives are gzipped tarballs. You can read more about the structure of these archives in `this Medium post
 <https://medium.com/radiant-earth-insights/archived-training-dataset-downloads-now-available-on-radiant-mlhub-7eb67daf094e>`_.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -115,14 +115,18 @@ Download a Collection Archive
 +++++++++++++++++++++++++++++
 
 You can download all the assets associated with a collection using the :meth:`Collection.download <radiant_mlhub.models.Collection.download>`
-method. This method takes a full output path (including file name) where the archive should be saved on the local file system. If a file of
-the same name already exists it will skip the download (unless you use ``exist_okay=False``, in which case a :exc:`FileExistsError` is
-raised). Collection archives are gzipped tarballs.
+method. This method takes a path to a directory on the local file system where the archive should be saved.
+
+If a file of the same name already exists, the client will check whether the downloaded file is complete by comparing its size against the
+size of the remote file. If they are the same size, the download is skipped, otherwise the download will be resumed from the point where it
+stopped. You can control this behavior using the ``if_exists`` argument. Setting this to ``"skip"`` will skip the download for existing
+files *without* checking for completeness (a bit faster since it doesn't require a network request), and setting this to ``"overwrite"``
+will overwrite any existing file.
 
 .. code-block:: python
 
     >>> source_collection.download('~/Downloads')
     28%|██▊       | 985.0/3496.9 [00:35<00:51, 48.31M/s]
 
-You can read more about the structure of these archives in `this Medium post
+Collection archives are gzipped tarballs. You can read more about the structure of these archives in `this Medium post
 <https://medium.com/radiant-earth-insights/archived-training-dataset-downloads-now-available-on-radiant-mlhub-7eb67daf094e>`_.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -169,14 +169,18 @@ class TestClient:
         expected_output_path.touch(exist_ok=True)
         original_size = expected_output_path.stat().st_size
 
-        # Test exist_okay True / no overwrite (default)
-        output_path = radiant_mlhub.client.download_archive(source_collection_archive, output_dir=tmp_path)
+        # Test if_exists = 'skip' (default)
+        output_path = radiant_mlhub.client.download_archive(
+            source_collection_archive,
+            output_dir=tmp_path,
+            if_exists='skip'
+        )
         assert output_path.stat().st_size == original_size
 
         # Test overwrite
-        output_path = radiant_mlhub.client.download_archive(source_collection_archive, overwrite=True)
+        output_path = radiant_mlhub.client.download_archive(
+            source_collection_archive,
+            output_dir=tmp_path,
+            if_exists='overwrite'
+        )
         assert output_path.stat().st_size > original_size
-
-        # Test error
-        with pytest.raises(FileExistsError):
-            radiant_mlhub.client.download_archive(source_collection_archive, exist_okay=False)


### PR DESCRIPTION
## Changes

* Ability to resume archive downloads
* Automatically retry requests that fail due to connection issues

### Resume Downloads

Adds the capability to resume a download in all download methods (`client.download_archive`, `Collection.download`, and `Dataset.download`). **This is a breaking change** since it changes the signature of those methods. They no longer accept `exist_okay` and `overwrite` arguments. Instead, there is a single `if_exists` argument that handles both of these cases and the case for resuming the download. Default behavior is to check if an existing file is complete by comparing size against the size of the remote archive. If it is not complete, the remaining bytes will be appended. If it is complete, the download is skipped.

### Automatic Retries

The `session.Session` class is now configured to retry on connection errors up to 3 times with a small backoff on each retry. I couldn't find a good way to test this using `requests_mock` (see getsentry/responses#135 for details on why), so for now I'm just keeping my fingers cross and hopefully one of our users can verify that it's working in real-life.

#24 