### PR TITLE
Allow user-defined profiles location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[Unreleased\]
+
+### Fixed
+
+* Allow user-defined `profiles` location (#27)
+
 ## \[v0.1.2\]
 
 ### Fixed

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -80,6 +80,13 @@ so that you do not need to explicitly set environment variables or pass in argum
 All profile configuration must be stored in a ``.mlhub/profiles`` file in your home directory. The ``profiles`` file uses the INI file
 structure supported by Python's ``configparser`` module `as described here <https://docs.python.org/3/library/configparser.html#supported-ini-file-structure>`_.
 
+.. hint::
+
+    If you do not have write access to the home directory on your machine, you can change the location of the ``profiles`` file using the ``MLHUB_HOME``
+    environment variables. For instance, setting ``MLHUB_HOME=/tmp/some-directory/.mlhub`` will cause the client to look for your profiles in a
+    ``/tmp/some-directory/.mlhub/profiles`` file. You may want to permanently set this environment variable to ensure the client continues to look in
+    the correct place for your profiles.
+
 The easiest way to configure a profile is using the ``mlhub configure`` CLI tool documented in the :ref:`CLI Tools section<CLI Tools>`:
 
 .. code-block:: console

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -20,13 +20,21 @@ Configuration
 
 If you have not done so already, you will need to register for an MLHub API key `here <http://dashboard.mlhub.earth/>`_.
 
-Once you have your API key, you will need to create a default profile by setting up a ``.mlhub/profiles`` file in your home directory:
+Once you have your API key, you will need to create a default profile by setting up a ``.mlhub/profiles`` file in your
+home directory. You can use the :ref:`mlhub configure <configure>` command line tool to do this:
 
 .. code-block:: console
 
     $ mlhub configure
     API Key: Enter your API key here...
     Wrote profile to /Users/youruser/.mlhub/profiles
+
+.. hint::
+
+    If you do not have write access to the home directory on your machine, you can change the location of the ``profiles`` file using the ``MLHUB_HOME``
+    environment variables. For instance, setting ``MLHUB_HOME=/tmp/some-directory/.mlhub`` will cause the client to look for your profiles in a
+    ``/tmp/some-directory/.mlhub/profiles`` file. You may want to permanently set this environment variable to ensure the client continues to look in
+    the correct place for your profiles.
 
 List Datasets
 +++++++++++++++++

--- a/radiant_mlhub/cli.py
+++ b/radiant_mlhub/cli.py
@@ -1,9 +1,11 @@
 import configparser
+import os
 from pathlib import Path
 
 import click
 
 from .__version__ import __version__
+from .session import Session
 
 
 @click.group()
@@ -22,13 +24,17 @@ def configure(profile, api_key):
     provide a --profile option, it will update the "default" profile. If you do not provide an --api-key
     option, you will be prompted to enter an API key by the tool.
 
+    If you need to change the location of the profiles file, set the MLHUB_HOME environment variable before
+    running this command.
+
     For details on profiles and authentication for the radiant_mlhub client, please see the official
     Authentication documentation:
 
     https://radiant-mlhub.readthedocs.io
     """
 
-    config_path = Path.home() / '.mlhub' / 'profiles'
+    mlhub_home = Path(os.getenv(Session.MLHUB_HOME_ENV_VARIABLE, Path.home() / '.mlhub'))
+    config_path = mlhub_home / 'profiles'
 
     config = configparser.ConfigParser()
     config.read(config_path)

--- a/radiant_mlhub/session.py
+++ b/radiant_mlhub/session.py
@@ -33,6 +33,7 @@ class Session(requests.Session):
     * Calls :meth:`requests.Response.raise_for_status` after all requests to raise exceptions for any status codes above 400.
     """
 
+    MLHUB_HOME_ENV_VARIABLE = 'MLHUB_HOME'
     API_KEY_ENV_VARIABLE = 'MLHUB_API_KEY'
     PROFILE_ENV_VARIABLE = 'MLHUB_PROFILE'
     ROOT_URL = 'https://api.radiant.earth/mlhub/v1/'
@@ -131,12 +132,15 @@ class Session(requests.Session):
 
     @classmethod
     def from_config(cls, profile: Optional[str] = None) -> 'Session':
-        """Create a session object by reading an API key from the given profile in the ``.mlhub/profiles`` file.
+        """Create a session object by reading an API key from the given profile in the ``profiles`` file. By default,
+        the client will look for the ``profiles`` file in a ``.mlhub`` directory in the user's home directory (as
+        determined by :meth:`Path.home <pathlib.Path.home>`). However, if an ``MLHUB_HOME`` environment variable is
+        present, the client will look in that directory instead.
 
         Parameters
         ----------
         profile: str, optional
-            The name of a profile configured in the ``.mlhub/profiles`` file.
+            The name of a profile configured in the ``profiles`` file.
 
         Returns
         -------
@@ -148,7 +152,8 @@ class Session(requests.Session):
             If the given config file does not exist, the given profile cannot be found, or there is no ``api_key`` property in the
             given profile section.
         """
-        config_path = Path.home() / '.mlhub/profiles'
+        mlhub_home = Path(os.getenv(Session.MLHUB_HOME_ENV_VARIABLE, Path.home() / '.mlhub'))
+        config_path = mlhub_home / 'profiles'
         if not config_path.exists():
             raise APIKeyNotFound(f'No file found at {config_path}')
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -10,14 +10,16 @@ class TestCLI:
         result = cli_runner.invoke(mlhub, ['--version'])
         assert result.output.rstrip('\n') == 'mlhub, version 0.1.2'
 
-    def test_configure(self, isolated_cli_runner, monkeypatch):
+    def test_configure(self, isolated_cli_runner):
         new_home = Path.cwd()
 
         # Monkeypatch the user's home directory to be the temp directory (CWD)
-        monkeypatch.setenv('HOME', str(new_home))  # Linux/Unix
-        monkeypatch.setenv('USERPROFILE', str(new_home))  # Windows
+        env = {
+            'HOME': str(new_home),
+            'USERPROFILE': str(new_home)
+        }
 
-        result = isolated_cli_runner.invoke(mlhub, ['configure'], input='testapikey\n')
+        result = isolated_cli_runner.invoke(mlhub, ['configure'], input='testapikey\n', env=env)
         assert result.exit_code == 0, result.output
 
         # Should create a profiles file in the "HOME" directory

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -32,3 +32,26 @@ class TestCLI:
         # Should abort if an api key exists and user does not confirm overwrite
         result = isolated_cli_runner.invoke(mlhub, ['configure'], input='testapikey\nn\n')
         assert result.exit_code == 1, result.output
+
+    def test_configure_user_defined_home(self, isolated_cli_runner):
+        new_home = Path.cwd()
+
+        mlhub_home = new_home / 'some-directory' / '.mlhub'
+        mlhub_home.mkdir(parents=True)
+
+        result = isolated_cli_runner.invoke(
+            mlhub,
+            ['configure'],
+            input='userdefinedhome\n',
+            env={'MLHUB_HOME': str(mlhub_home)}
+        )
+        assert result.exit_code == 0, result.output
+
+        # Should create a profiles file in the "HOME" directory
+        profile_path = mlhub_home / 'profiles'
+        assert profile_path.exists()
+
+        config = configparser.ConfigParser()
+        config.read(profile_path)
+
+        assert config.get('default', 'api_key') == 'userdefinedhome'

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -50,7 +50,7 @@ class TestResolveAPIKeys:
         session = get_session()
         assert session.params.get('key') == 'defaultapikey'
 
-    def test_api_key_from_named_profile(self, tmp_path, mock_profile):
+    def test_api_key_from_named_profile(self, mock_profile):
         """The API key from the given profile in ~/.mlhub/profiles is stored on the session."""
         session = get_session(profile='other-profile')
         assert session.params.get('key') == 'otherapikey'

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -62,6 +62,27 @@ class TestResolveAPIKeys:
         session = get_session()
         assert session.params.get('key') == 'environmentprofilekey'
 
+    def test_user_defined_mlhub_home(self, monkeypatch, tmp_path):
+        """If the MLHUB_HOME environment variable is set, the client should look for a profiles file in that directory.
+        """
+        # Create user-defined home directory
+        mlhub_home = tmp_path / 'some-directory' / '.mlhub'
+        mlhub_home.mkdir(parents=True)
+
+        # Create profile
+        config = configparser.ConfigParser()
+        config['default'] = {'api_key': 'userdefinedhome'}
+
+        # Save to profile file
+        with (mlhub_home / 'profiles').open('w') as dst:
+            config.write(dst)
+
+        # Monkeypatch the MLHUB_HOME variable
+        monkeypatch.setenv('MLHUB_HOME', str(mlhub_home.resolve()))
+
+        session = get_session()
+        assert session.params.get('key') == 'userdefinedhome'
+
     def test_from_env_error(self, monkeypatch):
         """Raises an exception if no MLHUB_API_KEY environment variable is found when explicitly loading session from environment."""
         # Ensure there is not MLHUB_API_KEY environment variable


### PR DESCRIPTION
## Proposed Changes

* If `MLHUB_HOME` environment variable is set client will look for `profiles` file in that location instead of the home directory.
* `mlhub configure` CLI tool also respects this variable when saving profiles

## Checklist

- [x] This PR is made against the `dev` branch (only releases and critical hotfixes should 
  be made against the `main` branch).
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

Closes #27 