### PR TITLE
Add Collection property for registry URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `Collection.registry_url` property to get the URL for the Collection's registry page ([#39](https://github.com/radiantearth/radiant-mlhub/pull/39))
 * Available as `conda` package via `conda-forge` (#34)
 
     ```console

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,35 +8,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Allow user-defined `profiles` location (#27)
+* Allow user-defined `profiles` location ([#27](https://github.com/radiantearth/radiant-mlhub/issues/27))
 
 ### Added
 
 * `Collection.registry_url` property to get the URL for the Collection's registry page ([#39](https://github.com/radiantearth/radiant-mlhub/pull/39))
-* Available as `conda` package via `conda-forge` (#34)
+* Available as `conda` package via `conda-forge` ([#34](https://github.com/radiantearth/radiant-mlhub/issues/29))
 
     ```console
     $ conda install -c conda-forge radiant-mlhub
     ```
 
-## \[v0.1.2\]
+## [v0.1.2]
 
 ### Fixed
 
-* Implicit dependency on `typing_extensions` (#29)
+* Implicit dependency on `typing_extensions` ([#29](https://github.com/radiantearth/radiant-mlhub/issues/29))
 
 ### Developer
 
 * Manually caches properties instead of using `functools.cached_property`/`backports.cached_property`
 
-## \[v0.1.1\]
+## [v0.1.1]
 
 ### Added
 
-* Ability to resume archive downloads(#24)
-* Automatically retry requests that fail due to connection issues (#24)
+* Ability to resume archive downloads([#24](https://github.com/radiantearth/radiant-mlhub/issues/24))
+* Automatically retry requests that fail due to connection issues ([#24](https://github.com/radiantearth/radiant-mlhub/issues/24))
 
-## \[v0.1.0\]
+## [v0.1.0]
 
 First working `alpha` release of the Radiant MLHub Python client. 
 
@@ -46,3 +46,7 @@ Includes support for:
 * Listing datasets and collections
 * Fetching datasets and collections by ID
 * Downloading collection archives
+
+[v0.1.2]: https://github.com/radiantearth/radiant-mlhub/releases/tag/v0.1.2
+[v0.1.1]: https://github.com/radiantearth/radiant-mlhub/releases/tag/v0.1.1
+[v0.1.0]: https://github.com/radiantearth/radiant-mlhub/releases/tag/v0.1.0

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -103,6 +103,13 @@ method. This is the recommended way of fetching a collection. This method return
     >>> collection.description
     'African Crops Kenya'
 
+For more information on a Collection, you can check out the MLHub Registry page:
+
+.. code-block:: python
+
+    >>> collection.registry_url
+    https://registry.mlhub.earth/10.14279/depositonce-10149/
+
 Downloading a Collection
 ++++++++++++++++++++++++
 

--- a/radiant_mlhub/models.py
+++ b/radiant_mlhub/models.py
@@ -167,6 +167,21 @@ class Collection(pystac.Collection):
         """
         return client.download_archive(self.id, output_dir=output_dir, if_exists=if_exists, **session_kwargs)
 
+    @property
+    def registry_url(self) -> Optional[str]:
+        """The URL of the registry page for this Collection. The URL is based on the DOI identifier
+        for the collection. If the Collection does not have a ``"sci:doi"`` property then
+        ``registry_url`` will be ``None``."""
+
+        # Some Collections don't publish the "scientific" extension in their "stac_extensions"
+        # attribute so we access this via "extra_fields" rather than through self.ext["scientific"].
+        print(self.extra_fields)
+        doi = self.extra_fields.get("sci:doi")
+        if doi is None:
+            return None
+
+        return f'https://registry.mlhub.earth/{doi}'
+
 
 class CollectionType(Enum):
     """Valid values for the type of a collection associated with a Radiant MLHub dataset."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,6 +43,17 @@ def source_collection(requests_mock):
 
 
 @pytest.fixture(scope='function')
+def source_collection_with_doi(requests_mock):
+    """Response for GET /collections/su_african_crops_south_sudan_labels."""
+    response_text = read_data_file('su_african_crops_south_sudan_labels.json')
+    endpoint = 'https://api.radiant.earth/mlhub/v1/collections/su_african_crops_south_sudan_labels'
+
+    requests_mock.get(endpoint, text=response_text)
+
+    yield endpoint
+
+
+@pytest.fixture(scope='function')
 def labels_collection(requests_mock):
     """Response for GET /collections/bigearthnet_v1_labels."""
     response_text = read_data_file('bigearthnet_v1_labels.json')

--- a/test/data/su_african_crops_south_sudan_labels.json
+++ b/test/data/su_african_crops_south_sudan_labels.json
@@ -1,0 +1,54 @@
+{
+    "anon:size": 12,
+    "anon:warning": "WARNING: The item geometries in this collection have been anonymized such that they exist somewhere within the bounding box extent listed within that item's geometry.",
+    "assets": {},
+    "description": "Labels for the labeled African crop dataset from Stanford University",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    24.0,
+                    1.0,
+                    36.0,
+                    13.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2017-01-01T00:00:00Z",
+                    "2017-12-31T00:00:00Z"
+                ]
+            ]
+        }
+    },
+    "id": "su_african_crops_south_sudan_labels",
+    "keywords": [],
+    "license": "CC-BY-SA-4.0",
+    "links": [
+        {
+            "href": "https://api.radiant.earth/mlhub/v1/collections/su_african_crops_south_sudan_labels",
+            "rel": "self",
+            "title": "Stanford University African Crop Dataset Labels",
+            "type": "application/json"
+        },
+        {
+            "href": "https://api.radiant.earth/mlhub/v1",
+            "rel": "root",
+            "title": null,
+            "type": "application/json"
+        }
+    ],
+    "properties": {},
+    "providers": [],
+    "sci:citation": "Rustowicz R., Cheong R., Wang L., Ermon S., Burke M., Lobell D. (2020) \"Semantic Segmentation of Crop Type in South Sudan\", Version 1.0, Radiant MLHub. [Date Accessed] https://doi.org/10.34911/rdnt.v6kx6nRustowicz R., Cheong R., Wang L., Ermon S., Burke M., Lobell D. (2020) \"Semantic Segmentation of Crop Type in South Sudan\", Version 1.0, Radiant MLHub. [Date Accessed] https://doi.org/10.34911/rdnt.v6kx6n",
+    "sci:doi": "10.34911/rdnt.v6kx6n",
+    "stac_extensions": [
+        "anonymized-location",
+        "label"
+    ],
+    "stac_version": "1.0.0-beta.2",
+    "summaries": {},
+    "title": "Stanford University African Crop Dataset Labels"
+}

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -46,6 +46,14 @@ class TestCollection:
         assert output_path == tmp_path / 'bigearthnet_v1_source.tar.gz'
         assert output_path.exists()
 
+    def test_get_registry_url(self, source_collection_with_doi):
+        collection = Collection.fetch('su_african_crops_south_sudan_labels')
+        assert collection.registry_url == 'https://registry.mlhub.earth/10.34911/rdnt.v6kx6n'
+
+    def test_get_registry_url_no_doi(self, source_collection):
+        collection = Collection.fetch('bigearthnet_v1_source')
+        assert collection.registry_url is None
+
 
 class TestDataset:
 


### PR DESCRIPTION
## Proposed Changes

* Adds `Collection.registry_url` property to get registry URL based on the DOI

   Some Collections do not have a `"sci:doi"` property. In this case, `Collection.registry_url` returns `None`.

## Checklist

- [x] This PR is made against the `dev` branch (only releases and critical hotfixes should 
  be made against the `main` branch).
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

#36 