### PR TITLE
Add Dataset attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* New attributes on `Dataset` class (`doi`, `citation`, and `registry_url`) ([#40](https://github.com/radiantearth/radiant-mlhub/pull/40))
 * `Collection.registry_url` property to get the URL for the Collection's registry page ([#39](https://github.com/radiantearth/radiant-mlhub/pull/39))
 * Available as `conda` package via `conda-forge` ([#34](https://github.com/radiantearth/radiant-mlhub/issues/29))
 

--- a/radiant_mlhub/models.py
+++ b/radiant_mlhub/models.py
@@ -245,10 +245,22 @@ class Dataset:
     (``bigearthnet_v1_labels``).
     """
 
-    def __init__(self, id: str, collections: List[dict], title: Optional[str] = None, **session_kwargs):
+    def __init__(
+        self,
+        id: str,
+        collections: List[dict],
+        title: Optional[str] = None,
+        registry: Optional[str] = None,
+        doi: Optional[str] = None,
+        citation: Optional[str] = None,
+        **session_kwargs
+    ):
         self.id = id
         self.title = title
         self.collection_descriptions = collections
+        self.registry_url = registry
+        self.doi = doi
+        self.citation = citation
         self.session_kwargs = session_kwargs
 
         self._collections: Optional['_CollectionList'] = None

--- a/radiant_mlhub/models.py
+++ b/radiant_mlhub/models.py
@@ -243,6 +243,20 @@ class Dataset:
     """Class that brings together multiple Radiant MLHub "collections" that are all considered part of a single "dataset". For instance,
     the ``bigearthnet_v1`` dataset is composed of both a source imagery collection (``bigearthnet_v1_source``) and a labels collection
     (``bigearthnet_v1_labels``).
+
+    Attributes
+    ----------
+
+    id : str
+        The dataset ID.
+    title : str or None
+        The title of the dataset (or ``None`` if dataset has no title).
+    registry_url : str or None
+        The URL to the registry page for this dataset, or ``None`` if no registry page exists.
+    doi : str or None
+        The DOI identifier for this dataset, or ``None`` if there is no DOI for this dataset.
+    citation: str or None
+        The citation information for this dataset, or ``None`` if there is no citation information.
     """
 
     def __init__(

--- a/test/data/bigearthnet_v1_dataset.json
+++ b/test/data/bigearthnet_v1_dataset.json
@@ -1,18 +1,21 @@
 {
+    "citation": "G. Sumbul, M. Charfuelan, B. Demir, V. Markl, \"BigEarthNet: A Large-Scale Benchmark Archive for Remote Sensing Image Understanding\", IEEE International Geoscience and Remote Sensing Symposium, pp. 5901-5904, Yokohama, Japan, 2019.",
     "collections": [
-        {
-            "id": "bigearthnet_v1_source",
-            "types": [
-                "source_imagery"
-            ]
-        },
-        {
-            "id": "bigearthnet_v1_labels",
-            "types": [
-                "labels"
-            ]
-        }
+      {
+        "id": "bigearthnet_v1_source",
+        "types": [
+            "source_imagery"
+        ]
+      },
+      {
+        "id": "bigearthnet_v1_labels",
+        "types": [
+            "labels"
+        ]
+      }
     ],
+    "doi": "10.14279/depositonce-10149",
     "id": "bigearthnet_v1",
+    "registry": "https://registry.mlhub.earth/10.14279/depositonce-10149",
     "title": "BigEarthNet"
 }

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -10,13 +10,6 @@ class TestCollection:
         assert len(collections) == 47
         assert isinstance(collections[0], Collection)
 
-    def test_get_collection_from_file(self, source_collection):
-        """The collection can be fetched by passing the MLHub URL to the from_file method."""
-        collection = Collection.from_file(source_collection)
-
-        assert isinstance(collection, Collection)
-        assert collection.description == 'BigEarthNet v1.0'
-
     def test_fetch_collection(self, source_collection):
         collection = Collection.fetch('bigearthnet_v1_source')
 
@@ -67,6 +60,11 @@ class TestDataset:
         dataset = Dataset.fetch('bigearthnet_v1')
         assert isinstance(dataset, Dataset)
         assert dataset.id == 'bigearthnet_v1'
+        assert dataset.registry_url == 'https://registry.mlhub.earth/10.14279/depositonce-10149'
+        assert dataset.doi == '10.14279/depositonce-10149'
+        assert dataset.citation == 'G. Sumbul, M. Charfuelan, B. Demir, V. Markl, \"BigEarthNet: A Large-Scale '\
+            'Benchmark Archive for Remote Sensing Image Understanding\", IEEE International Geoscience and Remote '\
+            'Sensing Symposium, pp. 5901-5904, Yokohama, Japan, 2019.'
 
     def test_dataset_collections(self, dataset, source_collection, labels_collection):
         dataset = Dataset.fetch('bigearthnet_v1')


### PR DESCRIPTION
## Proposed Changes

* Adds `doi`, `citation`, and `registry_url` instance attributes to the `Dataset` class

   I used `registry_url` in place of `registry` here to be consistent with the new property on the `Collection` class.

## Checklist

- [x] This PR is made against the `dev` branch (only releases and critical hotfixes should 
  be made against the `main` branch).
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

#36 