### PR TITLE
Properties to get archive sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Properties to get archive sizes without downloading (`Collection.archive_size` and
+  `Dataset.total_archive_size`) ([#44](https://github.com/radiantearth/radiant-mlhub/pull/40))
 * New attributes on `Dataset` class (`doi`, `citation`, and `registry_url`) ([#40](https://github.com/radiantearth/radiant-mlhub/pull/40))
 * `Collection.registry_url` property to get the URL for the Collection's registry page ([#39](https://github.com/radiantearth/radiant-mlhub/pull/39))
 * Available as `conda` package via `conda-forge` ([#34](https://github.com/radiantearth/radiant-mlhub/issues/29))

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -140,5 +140,13 @@ file. If they are the same size, the download is skipped, otherwise the download
 this behavior using the ``if_exists`` argument. Setting this to ``"skip"`` will skip the download for existing files *without* checking for
 completeness (a bit faster since it doesn't require a network request), and setting this to ``"overwrite"`` will overwrite any existing file.
 
+To check the size of the download archive without actually downloading it, you can use the 
+:attr:`Collection.total_archive_size` property.
+
+.. code-block:: python
+
+    >>> collection.archive_size
+    3504256089
+
 Collection archives are gzipped tarballs. You can read more about the structure of these archives in `this Medium post
 <https://medium.com/radiant-earth-insights/archived-training-dataset-downloads-now-available-on-radiant-mlhub-7eb67daf094e>`_.

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -137,5 +137,13 @@ network request), and setting this to ``"overwrite"`` will overwrite any existin
     >>> len(archive_paths)
     2
 
+To check the total size of the download archives for all collections in the dataset without actually
+downloading it, you can use the :attr:`Dataset.total_archive_size` property.
+
+.. code-block:: python
+
+    >>> dataset.total_archive_size
+    71311240007
+
 Collection archives are gzipped tarballs. You can read more about the structure of these archives in `this Medium post
 <https://medium.com/radiant-earth-insights/archived-training-dataset-downloads-now-available-on-radiant-mlhub-7eb67daf094e>`_.

--- a/radiant_mlhub/client.py
+++ b/radiant_mlhub/client.py
@@ -300,6 +300,40 @@ def get_collection_item(collection_id: str, item_id: str, **session_kwargs) -> d
         raise MLHubException(f'An unknown error occurred: {e.response.status_code} ({e.response.reason})')
 
 
+def get_archive_info(archive_id: str, **session_kwargs) -> dict:
+    """Gets info for the given archive from the ``/archive/{archive_id}/info`` endpoint as a
+    JSON-like dictionary.
+
+    The JSON object returned by the API has the following properties:
+
+    - ``collection``: The ID of the Collection that this archive is associated with.
+    - ``dataset``: The ID of the dataset that this archive's Collection belongs to.
+    - ``size``: The size of the archive (in bytes)
+    - ``types``: The types associated with this archive's Collection. Will be one of
+      ``"source_imagery"`` or ``"label"``.
+
+    Parameters
+    ----------
+    archive_id : str
+        The ID of the archive. This is the same as the Collection ID.
+    **session_kwargs
+        Keyword arguments passed directly to :func:`~radiant_mlhub.session.get_session`
+
+    Returns
+    -------
+    archive_info : dict
+        JSON-like dictionary representing the API response.
+    """
+    session = get_session(**session_kwargs)
+    try:
+        return session.get(f'archive/{archive_id}/info').json()
+
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            raise EntityDoesNotExist(f'Archive "{archive_id}" does not exist.') from None
+        raise MLHubException(f'An unknown error occurred: {e.response.status_code} ({e.response.reason})') from None
+
+
 def download_archive(
         archive_id: str,
         output_dir: Path = None,
@@ -319,7 +353,7 @@ def download_archive(
     Parameters
     ----------
     archive_id : str
-        The ID of the archive to download.
+        The ID of the archive to download. This is the same as the Collection ID.
     output_dir : Path
         Path to which the archive will be downloaded. Defaults to the current working directory.
     if_exists : str, optional

--- a/test/cassettes/test_models/TestCollection.test_get_archive_size.yaml
+++ b/test/cassettes/test_models/TestCollection.test_get_archive_size.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - 'radiant_mlhub/0.1.3 (Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT
+        2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64)'
+    method: GET
+    uri: https://api.radiant.earth/mlhub/v1/collections/bigearthnet_v1_labels
+  response:
+    body:
+      string: "{\n    \"assets\": {},\n    \"description\": \"BigEarthNet v1.0\",\n
+        \   \"extent\": {\n        \"spatial\": {\n            \"bbox\": [\n                [\n
+        \                   -9.00023345437725,\n                    1.7542686833884724,\n
+        \                   83.44558248555553,\n                    68.02168200047284\n
+        \               ]\n            ]\n        },\n        \"temporal\": {\n            \"interval\":
+        [\n                [\n                    \"2017-06-13T10:10:31Z\",\n                    \"2018-05-29T11:54:01Z\"\n
+        \               ]\n            ]\n        }\n    },\n    \"id\": \"bigearthnet_v1_labels\",\n
+        \   \"keywords\": [],\n    \"license\": \"CDLA-Permissive-1.0\",\n    \"links\":
+        [\n        {\n            \"href\": \"https://api.radiant.earth/mlhub/v1/collections/bigearthnet_v1_labels\",\n
+        \           \"rel\": \"self\",\n            \"title\": null,\n            \"type\":
+        \"application/json\"\n        },\n        {\n            \"href\": \"https://api.radiant.earth/mlhub/v1\",\n
+        \           \"rel\": \"root\",\n            \"title\": null,\n            \"type\":
+        \"application/json\"\n        }\n    ],\n    \"properties\": {},\n    \"providers\":
+        [\n        {\n            \"description\": null,\n            \"name\": \"BigEarthNet\",\n
+        \           \"roles\": [\n                \"processor\",\n                \"licensor\"\n
+        \           ],\n            \"url\": \"http://bigearth.net\"\n        }\n
+        \   ],\n    \"sci:citation\": \"G. Sumbul, M. Charfuelan, B. Demir, V. Markl,
+        \\\"BigEarthNet: A Large-Scale Benchmark Archive for Remote Sensing Image
+        Understanding\\\", IEEE International Geoscience and Remote Sensing Symposium,
+        pp. 5901-5904, Yokohama, Japan, 2019.\",\n    \"sci:doi\": \"10.14279/depositonce-10149\",\n
+        \   \"stac_extensions\": [\n        \"label\",\n        \"scientific\"\n    ],\n
+        \   \"stac_version\": \"1.0.0-beta.2\",\n    \"summaries\": {},\n    \"title\":
+        null\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1747'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 May 2021 16:23:22 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - 'radiant_mlhub/0.1.3 (Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT
+        2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64)'
+    method: GET
+    uri: https://api.radiant.earth/mlhub/v1/archive/bigearthnet_v1_labels/info
+  response:
+    body:
+      string: "{\n    \"collection\": \"bigearthnet_v1_labels\",\n    \"dataset\":
+        \"bigearthnet_v1\",\n    \"size\": 173029030,\n    \"types\": [\n        \"labels\"\n
+        \   ]\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '140'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 May 2021 16:23:22 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_models/TestDataset.test_total_archive_size.yaml
+++ b/test/cassettes/test_models/TestDataset.test_total_archive_size.yaml
@@ -1,0 +1,170 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - 'radiant_mlhub/0.1.3 (Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT
+        2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64)'
+    method: GET
+    uri: https://api.radiant.earth/mlhub/v1/datasets/bigearthnet_v1
+  response:
+    body:
+      string: "{\n    \"citation\": \"G. Sumbul, M. Charfuelan, B. Demir, V. Markl,
+        \\\"BigEarthNet: A Large-Scale Benchmark Archive for Remote Sensing Image
+        Understanding\\\", IEEE International Geoscience and Remote Sensing Symposium,
+        pp. 5901-5904, Yokohama, Japan, 2019.\",\n    \"collections\": [\n        {\n
+        \           \"id\": \"bigearthnet_v1_source\",\n            \"types\": [\n
+        \               \"source_imagery\"\n            ]\n        },\n        {\n
+        \           \"id\": \"bigearthnet_v1_labels\",\n            \"types\": [\n
+        \               \"labels\"\n            ]\n        }\n    ],\n    \"doi\":
+        \"10.14279/depositonce-10149\",\n    \"id\": \"bigearthnet_v1\",\n    \"registry\":
+        \"https://registry.mlhub.earth/10.14279/depositonce-10149\",\n    \"title\":
+        \"BigEarthNet\"\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '713'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 May 2021 16:25:37 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - 'radiant_mlhub/0.1.3 (Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT
+        2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64)'
+    method: GET
+    uri: https://api.radiant.earth/mlhub/v1/collections/bigearthnet_v1_source
+  response:
+    body:
+      string: "{\n    \"description\": \"BigEarthNet v1.0\",\n    \"extent\": {\n
+        \       \"spatial\": {\n            \"bbox\": [\n                [\n                    -9.00023345437725,\n
+        \                   1.7542686833884724,\n                    83.44558248555553,\n
+        \                   68.02168200047284\n                ]\n            ]\n
+        \       },\n        \"temporal\": {\n            \"interval\": [\n                [\n
+        \                   \"2017-06-13T10:10:31Z\",\n                    \"2018-05-29T11:54:01Z\"\n
+        \               ]\n            ]\n        }\n    },\n    \"id\": \"bigearthnet_v1_source\",\n
+        \   \"keywords\": [],\n    \"license\": \"CDLA-Permissive-1.0\",\n    \"links\":
+        [\n        {\n            \"href\": \"https://api.radiant.earth/mlhub/v1/collections/bigearthnet_v1_source\",\n
+        \           \"rel\": \"self\",\n            \"title\": null,\n            \"type\":
+        \"application/json\"\n        },\n        {\n            \"href\": \"https://api.radiant.earth/mlhub/v1\",\n
+        \           \"rel\": \"root\",\n            \"title\": null,\n            \"type\":
+        \"application/json\"\n        }\n    ],\n    \"properties\": {},\n    \"providers\":
+        [\n        {\n            \"description\": null,\n            \"name\": \"BigEarthNet\",\n
+        \           \"roles\": [\n                \"processor\",\n                \"licensor\"\n
+        \           ],\n            \"url\": \"http://bigearth.net\"\n        }\n
+        \   ],\n    \"sci:citation\": \"G. Sumbul, M. Charfuelan, B. Demir, V. Markl,
+        \\\"BigEarthNet: A Large-Scale Benchmark Archive for Remote Sensing Image
+        Understanding\\\", IEEE International Geoscience and Remote Sensing Symposium,
+        pp. 5901-5904, Yokohama, Japan, 2019.\",\n    \"sci:doi\": \"10.14279/depositonce-10149\",\n
+        \   \"stac_extensions\": [\n        \"eo\",\n        \"scientific\"\n    ],\n
+        \   \"stac_version\": \"1.0.0-beta.2\",\n    \"summaries\": {},\n    \"title\":
+        null\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1726'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 May 2021 16:25:38 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - 'radiant_mlhub/0.1.3 (Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT
+        2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64)'
+    method: GET
+    uri: https://api.radiant.earth/mlhub/v1/archive/bigearthnet_v1_source/info
+  response:
+    body:
+      string: "{\n    \"collection\": \"bigearthnet_v1_source\",\n    \"dataset\":
+        \"bigearthnet_v1\",\n    \"size\": 71138210977,\n    \"types\": [\n        \"source_imagery\"\n
+        \   ]\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 May 2021 16:25:38 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - 'radiant_mlhub/0.1.3 (Darwin Kernel Version 19.6.0: Mon Apr 12 20:57:45 PDT
+        2021; root:xnu-6153.141.28.1~1/RELEASE_X86_64)'
+    method: GET
+    uri: https://api.radiant.earth/mlhub/v1/archive/bigearthnet_v1_labels/info
+  response:
+    body:
+      string: "{\n    \"collection\": \"bigearthnet_v1_labels\",\n    \"dataset\":
+        \"bigearthnet_v1\",\n    \"size\": 173029030,\n    \"types\": [\n        \"labels\"\n
+        \   ]\n}"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '140'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 May 2021 16:25:39 GMT
+      Server:
+      - gunicorn
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -59,6 +59,11 @@ class TestCollection:
 
         assert collection.registry_url is None
 
+    @pytest.mark.vcr
+    def test_get_archive_size(self):
+        collection = Collection.fetch('bigearthnet_v1_labels')
+        assert collection.archive_size == 173029030
+
 
 class TestDataset:
 
@@ -105,3 +110,9 @@ class TestDataset:
     def test_collections_list(self):
         dataset = Dataset.fetch('bigearthnet_v1')
         assert dataset.collections.__repr__() == '[<Collection id=bigearthnet_v1_source>, <Collection id=bigearthnet_v1_labels>]'
+
+    @pytest.mark.vcr
+    @pytest.mark.skip(reason="vcrpy does not handle multithreaded requests.")
+    def test_total_archive_size(self):
+        dataset = Dataset.fetch('bigearthnet_v1')
+        assert dataset.total_archive_size == 71311240007


### PR DESCRIPTION
## Proposed Changes

* Adds `Collection.archive_size` to get size of tarball archive (or `None` if the archive does not exist)
* Adds `Dataset.total_archive_size` to get total size of all collection archives for the dataset (or `None` if no collection archives exist)

## Checklist

- [x] This PR is made against the `dev` branch (only releases and critical hotfixes should 
  be made against the `main` branch).
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
   *Due to limitations in VCR.py for handling requests in multiple threads, I've marked one test to skip. This test passes when
   using actual network requests.*
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

Closes #35 