### PR TITLE
Hotfix/gh 47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## \[Unreleased\]
+
+### Fixed
+
+* `api_key` argument from `Dataset.fetch` used by `Dataset` instance for downstream requests
+  ([#48](https://github.com/radiantearth/radiant-mlhub/pull/48))
 
 ## [v0.2.0]
 

--- a/radiant_mlhub/models.py
+++ b/radiant_mlhub/models.py
@@ -403,7 +403,10 @@ class Dataset:
         -------
         dataset : Dataset
         """
-        return cls(**client.get_dataset(dataset_id, **session_kwargs))
+        return cls(
+            **client.get_dataset(dataset_id, **session_kwargs),
+            **session_kwargs
+        )
 
     def download(
             self,

--- a/radiant_mlhub/models.py
+++ b/radiant_mlhub/models.py
@@ -386,7 +386,7 @@ class Dataset:
         ------
         dataset : Dataset
         """
-        yield from map(lambda d: cls(**d), client.list_datasets(**session_kwargs))
+        yield from map(lambda d: cls(**d, **session_kwargs), client.list_datasets(**session_kwargs))
 
     @classmethod
     def fetch(cls, dataset_id: str, **session_kwargs) -> 'Dataset':

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,7 +1,9 @@
 import pystac
 import pytest
+from urllib.parse import urljoin
 
 from radiant_mlhub.models import Collection, Dataset
+from radiant_mlhub.session import Session
 
 
 class TestCollection:
@@ -116,3 +118,79 @@ class TestDataset:
     def test_total_archive_size(self):
         dataset = Dataset.fetch('bigearthnet_v1')
         assert dataset.total_archive_size == 71311240007
+
+
+class TestDatasetNoProfile:
+    DATASET = {
+        "citation": "Fake citation",
+        "collections": [
+            {
+                "id": "test_collection",
+                "types": [
+                    "source_imagery"
+                ]
+            }
+        ],
+        "doi": "10.12345/depositonce-12345",
+        "id": "test_dataset",
+        "registry": "https://registry.mlhub.earth/10.12345/depositonce-12345",
+        "title": "Test Dataset"
+    }
+
+    COLLECTION = {
+        "description": "Test Collection",
+        "extent": {
+            "spatial": {
+                "bbox": [
+                    [
+                        -9.00023345437725, 1.7542686833884724,
+                        83.44558248555553,68.02168200047284
+                    ]
+                ]
+            },
+            "temporal": {
+                "interval": [
+                    [
+                        "2017-06-13T10:10:31Z",
+                        "2018-05-29T11:54:01Z"
+                    ]
+                ]
+            }
+        },
+        "id": "test_collection",
+        "links": [],
+        "license": "Test License",
+        "properties": {},
+        "stac_version": "1.0.0-beta.2"
+    }
+    @pytest.fixture(scope='function', autouse=True)
+    def mock_profile(self, monkeypatch, tmp_path):
+        """Overwrite the fixture in conftest so we don't set up an API key here"""
+
+        # Monkeypatch the user's home directory to be the temp directory
+        # This prevents the client from automatically finding any profiles configured in the user's
+        # home directory.
+        monkeypatch.setenv('HOME', str(tmp_path))  # Linux/Unix
+        monkeypatch.setenv('USERPROFILE', str(tmp_path))  # Windows
+
+        yield
+
+    def test_get_collections_with_api_key(self, requests_mock):
+        """The Dataset class should use any API keys passed during instantiation for listing
+        collections."""
+        dataset_id = self.DATASET["id"]
+        collection_id = self.COLLECTION["id"]
+        api_key = 'test_api_key'
+
+        dataset_url = urljoin(Session.ROOT_URL, f'datasets/{dataset_id}')
+        requests_mock.get(dataset_url, json=self.DATASET)
+
+        collection_url = urljoin(Session.ROOT_URL, f'collections/{collection_id}')
+        requests_mock.get(collection_url, json=self.COLLECTION)
+
+        dataset = Dataset.fetch(dataset_id, api_key=api_key)
+        _ = dataset.collections
+
+        history = requests_mock.request_history
+        assert len(history) == 2
+        assert "key=test_api_key" in history[1].url

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -144,7 +144,7 @@ class TestDatasetNoProfile:
                 "bbox": [
                     [
                         -9.00023345437725, 1.7542686833884724,
-                        83.44558248555553,68.02168200047284
+                        83.44558248555553, 68.02168200047284
                     ]
                 ]
             },
@@ -163,6 +163,7 @@ class TestDatasetNoProfile:
         "properties": {},
         "stac_version": "1.0.0-beta.2"
     }
+
     @pytest.fixture(scope='function', autouse=True)
     def mock_profile(self, monkeypatch, tmp_path):
         """Overwrite the fixture in conftest so we don't set up an API key here"""

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -176,9 +176,9 @@ class TestDatasetNoProfile:
 
         yield
 
-    def test_get_collections_with_api_key(self, requests_mock):
-        """The Dataset class should use any API keys passed during instantiation for listing
-        collections."""
+    def test_fetch_with_api_key(self, requests_mock):
+        """The Dataset class should use any API keys passed to Dataset.fetch in methods on the
+        resulting Dataset instance."""
         dataset_id = self.DATASET["id"]
         collection_id = self.COLLECTION["id"]
         api_key = 'test_api_key'
@@ -194,4 +194,25 @@ class TestDatasetNoProfile:
 
         history = requests_mock.request_history
         assert len(history) == 2
-        assert "key=test_api_key" in history[1].url
+        assert f"key={api_key}" in history[1].url
+
+    def test_list_with_api_key(self, requests_mock):
+        """The Dataset class should use any API keys passed to Dataset.list in methods on the
+        resulting dataset instances."""
+
+        collection_id = self.COLLECTION["id"]
+        api_key = 'test_api_key'
+
+        dataset_url = urljoin(Session.ROOT_URL, 'datasets')
+        requests_mock.get(dataset_url, json=[self.DATASET])
+
+        collection_url = urljoin(Session.ROOT_URL, f'collections/{collection_id}')
+        requests_mock.get(collection_url, json=self.COLLECTION)
+
+        datasets = Dataset.list(api_key=api_key)
+        for dataset in datasets:
+            _ = dataset.collections
+
+        history = requests_mock.request_history
+        assert len(history) == 2
+        assert f"key={api_key}" in history[1].url


### PR DESCRIPTION
## Proposed Changes

* Passes session arguments from `Dataset.fetch` to `Dataset.__init__` so they can be used for internal requests

## Checklist

- [ ] ~This PR is made against the `dev` branch (only releases and critical hotfixes should 
  be made against the `main` branch).~ **Hotfix made against `main`**
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

* #47 