### PR TITLE
Fix get_dataset

### DIFF
--- a/radiant_mlhub/client.py
+++ b/radiant_mlhub/client.py
@@ -1,6 +1,7 @@
 """Low-level functions for making requests to MLHub API endpoints."""
 
 import itertools as it
+import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
@@ -17,6 +18,9 @@ except ImportError:  # pragma: no cover
 
 from .exceptions import EntityDoesNotExist, MLHubException
 from .session import get_session
+
+
+DOI_PATTERN = re.compile(r"^(10\.\d{4,5}\/[\S]+[^;,.\s])$")
 
 
 def _download(
@@ -211,13 +215,10 @@ def get_dataset(dataset_id_or_doi: str, **session_kwargs) -> dict:
     -------
     dataset : dict
     """
-    try:
+    if DOI_PATTERN.match(dataset_id_or_doi):
+        return get_dataset_by_doi(dataset_id_or_doi, **session_kwargs)
+    else:
         return get_dataset_by_id(dataset_id_or_doi, **session_kwargs)
-    except EntityDoesNotExist:
-        try:
-            return get_dataset_by_doi(dataset_id_or_doi, **session_kwargs)
-        except EntityDoesNotExist:
-            raise EntityDoesNotExist(f"Could not find dataset with ID or DOI matching '{dataset_id_or_doi}'")
 
 
 def list_collections(**session_kwargs) -> List[dict]:

--- a/radiant_mlhub/client.py
+++ b/radiant_mlhub/client.py
@@ -1,7 +1,6 @@
 """Low-level functions for making requests to MLHub API endpoints."""
 
 import itertools as it
-import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
@@ -18,9 +17,6 @@ except ImportError:  # pragma: no cover
 
 from .exceptions import EntityDoesNotExist, MLHubException
 from .session import get_session
-
-
-DOI_PATTERN = re.compile(r"^(10\.\d{4,5}\/[\S]+[^;,.\s])$")
 
 
 def _download(
@@ -215,7 +211,10 @@ def get_dataset(dataset_id_or_doi: str, **session_kwargs) -> dict:
     -------
     dataset : dict
     """
-    if DOI_PATTERN.match(dataset_id_or_doi):
+    # DOI RegExs are pretty tricky
+    # (https://stackoverflow.com/questions/27910/finding-a-doi-in-a-document-or-page), so instead we
+    # rely on the fact that we'll never have a "/" in a dataset ID.
+    if "/" in dataset_id_or_doi:
         return get_dataset_by_doi(dataset_id_or_doi, **session_kwargs)
     else:
         return get_dataset_by_id(dataset_id_or_doi, **session_kwargs)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -181,16 +181,13 @@ class TestDataset:
         assert len(history) == 1
         assert urlsplit(history[0].url).path == urlsplit(endpoint).path
 
-    def test_get_dataset_uses_id_first(self, requests_mock):
+    def test_get_dataset_uses_id_when_appropriate(self, requests_mock):
         dataset_id = "ref_african_crops_kenya_02"
-        dataset_doi = "10.6084/m9.figshare.12047478.v2"
 
         response_content = util.get_api_response(f"datasets/{dataset_id}.json")
-        doi_endpoint = f"https://api.radiant.earth/mlhub/v1/datasets/doi/{dataset_doi}"
         id_endpoint = f"https://api.radiant.earth/mlhub/v1/datasets/{dataset_id}"
 
         requests_mock.get(id_endpoint, status_code=200, text=response_content)
-        requests_mock.get(doi_endpoint, status_code=404)
 
         Dataset.fetch(dataset_id)
 
@@ -199,23 +196,20 @@ class TestDataset:
         assert len(history) == 1
         assert urlsplit(history[0].url).path == urlsplit(id_endpoint).path
 
-    def test_get_dataset_falls_back_to_doi(self, requests_mock):
+    def test_get_dataset_uses_doi_when_appropriate(self, requests_mock):
         dataset_doi = "10.6084/m9.figshare.12047478.v2"
 
         response_content = util.get_api_response("datasets/ref_african_crops_kenya_02.json")
         doi_endpoint = f"https://api.radiant.earth/mlhub/v1/datasets/doi/{dataset_doi}"
-        id_endpoint = f"https://api.radiant.earth/mlhub/v1/datasets/{dataset_doi}"
 
-        requests_mock.get(id_endpoint, status_code=404)
         requests_mock.get(doi_endpoint, status_code=200, text=response_content)
 
         Dataset.fetch(dataset_doi)
 
         history = requests_mock.request_history
 
-        assert len(history) == 2
-        assert urlsplit(history[0].url).path == urlsplit(id_endpoint).path
-        assert urlsplit(history[1].url).path == urlsplit(doi_endpoint).path
+        assert len(history) == 1
+        assert urlsplit(history[0].url).path == urlsplit(doi_endpoint).path
 
     # https://github.com/kevin1024/vcrpy/issues/295
     @pytest.mark.vcr


### PR DESCRIPTION
## Proposed Changes

* Use RegEx to detect DOI input to `get_dataset` and delegate to the appropriate endpoint. This means we don't make an extra API call when we don't need to and we also don't rely on specific error codes from the API when falling back to the DOI endpoint.

## Checklist

- [ ] I have updated/added any relevant documentation
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

*Please link to any issues that this PR relates to.*