### PR TITLE
Remove/python3.6

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Support for Python 3.6 ([#61](https://github.com/radiantearth/radiant-mlhub/pull/58))
+
 ### Fixed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@
 
 API reference and Getting Started guides are available on [Read the Docs](https://radiant-mlhub.readthedocs.io/en/latest/).
 
+## Python Version Support
+
+The `radiant_mlhub` Python client requires Python >= 3.7. 
+
+This library aligns with PySTAC in following the recommendations of
+[NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) in deprecating support for Python
+versions. This means that users can expect support for Python 3.7 to be removed from the `main` branch
+after Dec 26, 2021 and therefore from the next release after that date. 
+
 ## Design Decisions
 
 Major architectural and design decisions are documented using [Architectural Design Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) stored in the [`docs/adr`](./docs/adr) directory.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -49,5 +48,5 @@ setuptools.setup(
         'Slack': 'https://mlhubearth.slack.com',
         'Documentation': 'https://radiant-mlhub.readthedocs.io/en/latest/'
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
## Proposed Changes

* Remove support for Python 3.6

This change is in anticipation of bumping to PySTAC >= 1.0, which removes support for Python 3.6

## Checklist

- [x] I have updated/added any relevant documentation
- [ ] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

N/A