### PR TITLE
Bump CI version of python 3.10 from beta3 to latest.

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -34,16 +34,16 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-          - "3.10.0-beta.3"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
         exclude:
-          - python-version: "3.10.0-beta.3"
+          - python-version: "3.10"
             os: windows-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Proposed Changes

* Fixes a [CI build problem I noticed with python 3.10 on ubuntu](https://github.com/radiantearth/radiant-mlhub/runs/5362413617?check_suite_focus=true).  Bumps the github workflow to use python 3.10 instead of a beta.

## Checklist

- [x] N/A - I have updated/added any relevant documentation
- [x] N/A - I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] N/A - Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

N/A