### PR TITLE
Fix missing python package typing_extensions

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -72,10 +72,10 @@ jobs:
           flake8_nb examples/
           mypy radiant_mlhub
 
-  # test importing all top-level modules, without polluting the package namespace
+  # verify importing all top-level modules, without polluting the package namespace
   # with requirements_testing.txt dependencies. (this simulates an end-user
   # install of the radiant-mlhub package).
-  test_import_package:
+  verify_import_package:
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -107,6 +107,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
-          python -m "from radiant_mlhub import *"
-          python -m "from radiant_mlhub.client import *"
-          python -m "from radiant_mlhub.models import *"
+          python -c "from radiant_mlhub import *"
+          python -c "from radiant_mlhub.client import *"
+          python -c "from radiant_mlhub.models import *"

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Import radiant_mlhub
         run: |
-          python -m pip install--upgrade pip
+          python -m pip install --upgrade pip
           pip install .
           python -m "from radiant_mlhub import *"
           python -m "from radiant_mlhub.client import *"

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -71,3 +71,42 @@ jobs:
           flake8
           flake8_nb examples/
           mypy radiant_mlhub
+
+  # test importing all top-level modules, without polluting the package namespace
+  # with requirements_testing.txt dependencies. (this simulates an end-user
+  # install of the radiant-mlhub package).
+  test_import_package:
+    strategy:
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        exclude:
+          - python-version: "3.10"
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Import radiant_mlhub
+        run: |
+          python -m pip install--upgrade pip
+          pip install .
+          python -m "from radiant_mlhub import *"
+          python -m "from radiant_mlhub.client import *"
+          python -m "from radiant_mlhub.models import *"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Developer
 
+- Fix missing dependency: typing_extensions. Improve CI jobs. ([#79])(https://github.com/radiantearth/radiant-mlhub/pull/79)
+
 ## [v0.4.0]
 
 ### Added

--- a/radiant_mlhub/client/datasets.py
+++ b/radiant_mlhub/client/datasets.py
@@ -1,12 +1,17 @@
 import os
+import sys
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union, cast
 
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 from requests.exceptions import HTTPError
-from typing_extensions import TypedDict
 
 from ..exceptions import EntityDoesNotExist, MLHubException
 from ..session import get_session

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         'pystac~=1.1',
         'click>=7.1.2,<9.0.0',
         'tqdm~=4.56',
+        'typing_extensions >= 3.7; python_version < "3.8"',
     ],
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
## Proposed Changes

* Add a CI job to test for a regression of this bug: https://github.com/radiantearth/radiant-mlhub/issues/29
* Conditional import of `typing_extensions`.

## Checklist

- [ ] I have updated/added any relevant documentation
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

* https://github.com/radiantearth/radiant-mlhub/issues/29