### PR TITLE
Do not fail docs build on warnings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,6 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 formats:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Developer
 
 - Fix missing dependency: typing_extensions. Improve CI jobs. ([#79])(https://github.com/radiantearth/radiant-mlhub/pull/79)
+- Allow ReadTheDocs builds to succeed if warnings are emitted ([#80])(https://github.com/radiantearth/radiant-mlhub/pull/80)
 
 ## [v0.4.0]
 


### PR DESCRIPTION
## Proposed Changes

* Update ReadTheDocs config to not fail builds for warnings. 

    We were getting some warnings like the following that were causing the build to fail:

    ```
    WARNING: duplicate label submodules, other instance in /Users/jduckworth/Code/ml-hub/radiant-mlhub/docs/source/api/radiant_mlhub.rst
    ```
    
    I think the solution for this would be to add a [`:noindex:` directive](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directives) to one of the instances, but since we are using `sphinx-apidoc` to autogenerate the `docs/source/api/*` files, there does not seem to be an easy way to solve this. It's possible we could overwrite the [templates that `sphinx-apidoc`](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html#cmdoption-sphinx-apidoc-0) uses to generate these files, but it doesn't seem worth the effort.

## Checklist

- [ ] I have updated/added any relevant documentation
- [ ] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)
