### PR TITLE
Remove Python 3.7 support.

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -79,7 +78,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove Python 3.7 support.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ API reference and Getting Started guides are available on [Read the Docs](https:
 
 ## Python Version Support
 
-The `radiant_mlhub` Python client requires Python >= 3.7. 
+The `radiant_mlhub` Python client requires Python >= 3.8.
 
 This library aligns with PySTAC in following the recommendations of
 [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) in deprecating support for Python
-versions. This means that users can expect support for Python 3.7 to be removed from the `main` branch
-after Dec 26, 2021 and therefore from the next release after that date. 
+versions. This means that users can expect support for Python 3.8 to be removed from the `main` branch
+after April 14, 2023 and therefore from the next release after that date.
 
 ## Design Decisions
 

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,10 @@ setuptools.setup(
         'pystac~=1.1',
         'click>=7.1.2,<9.0.0',
         'tqdm~=4.56',
-        'typing_extensions >= 3.7; python_version < "3.8"',
     ],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -53,5 +51,5 @@ setuptools.setup(
         'Slack': 'https://mlhubearth.slack.com',
         'Documentation': 'https://radiant-mlhub.readthedocs.io/en/latest/'
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
## Proposed Changes

* Remove Python 3.7 support. This was already broadcast in the README. `pystac` is going to remove Python 3.7 imminently. 

## Checklist

- [x] I have updated/added any relevant documentation
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

N/A