### PR TITLE
fixing bugs in radiant_mlhub readthedocs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-
+- Fix bugs in readthedocs. ([145](https://github.com/radiantearth/radiant-mlhub/pull/145))
 ### Deprecated
 
 ### Developer

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -5,11 +5,11 @@ A **collection** represents either a group of related labels or a group of
 related source imagery for a given time period and geographic area. All
 collections in the Radiant MLHub API are valid `STAC Collections
 <https://github.com/radiantearth/stac-spec/tree/master/collection-spec>`_. For
-instance, the ``ref_landcovernet_v1_source`` collection catalogs the source
-imagery associated with the LandCoverNet dataset, while the
-``ref_landcovernet_v1_labels`` collection catalogs the land cover labels
+instance, the ``umd_mali_crop_type_source`` collection catalogs the source
+imagery associated with the 2019 Mali CropType dataset, while the
+``umd_mali_crop_type_labels`` collection catalogs the land cover labels
 associated with this imagery. These collections are considered part of a single
-``ref_landcovernet_v1`` **dataset** (see the :ref:`Datasets` documentation for
+``umd_mali_crop_type`` **dataset** (see the :ref:`Datasets` documentation for
 details on working with datasets).
 
 .. hint::
@@ -155,13 +155,13 @@ Low-level client
 
 The Radiant MLHub ``/archive/{archive_id}`` endpoint allows you to download an
 archive of all assets associated with a given collection. You can use the
-low-level :func:`~radiant_mlhub.client.download_archive` function to download
+low-level :func:`~radiant_mlhub.client.download_collection_archive` function to download
 the archive to your local file system.
 
 .. code-block:: python
 
-    >>> from radiant_mlhub.client import download_archive
-    >>> archive_path = download_archive('sn1_AOI_1_RIO')
+    >>> from radiant_mlhub.client import download_collection_archive
+    >>> archive_path = download_collection_archive('sn1_AOI_1_RIO')
     28%|██▊       | 985.0/3496.9 [00:35<00:51, 48.31M/s]
     >>> archive_path
     PosixPath('/path/to/current/directory/sn1_AOI_1_RIO.tar.gz')

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -97,7 +97,7 @@ into two types:
 
 * ``source_imagery``: Collections of source imagery associated with the dataset
 * ``labels``: Collections of labeled data associated with the dataset (these collections implement the
-  `STAC Label Extension <https://github.com/radiantearth/stac-spec/tree/master/extensions/label>`_)
+  `STAC Label Extension <https://github.com/stac-extensions/label>`_)
 
 To list all the collections associated with a dataset use the :attr:`~radiant_mlhub.models.Dataset.collections` attribute.
 

--- a/docs/source/ml_models.rst
+++ b/docs/source/ml_models.rst
@@ -37,18 +37,21 @@ You can fetch a model by ID using :meth:`MLModel.fetch <radiant_mlhub.models.MLM
 .. code-block:: python
 
     >>> model = MLModel.fetch('model-cyclone-wind-estimation-torchgeo-v1')
-    >>> mode.assets
-    {'inferencing-checkpoint': <Asset href=https://zenodo.org/record/5773331/files/last.ckpt?download=1>,
+    >>> model.assets
+    {'inferencing-compose': <Asset href=https://raw.githubusercontent.com/RadiantMLHub/cyclone-model-torchgeo/main/inferencing.yml>,
+ 'inferencing-checkpoint': <Asset href=https://zenodo.org/record/5773331/files/last.ckpt?download=1>}
     >>> len(first_model.links)
-    7
+    8
     >>> # print only the ml-model and mlhub related links
+    >>> from pprint import pprint
     >>> pprint([ link for link in first_model.links if 'ml-model:' in link.rel or 'mlhub:' in link.rel])
-    [<Link rel=ml-model:inferencing-image target=docker://docker.io/radiantearth/cyclone-model-torchgeo:1>,
-     <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/nasa_tropical_storm_competition_train_source>,
-     <Link rel=mlhub:training-dataset target=https://mlhub.earth/data/nasa_tropical_storm_competition>]
+    [<Link rel=ml-model:inferencing-image target=docker://docker.io/radiantearth/crop-detection-dl:1>,
+ <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/ref_african_crops_kenya_02_source>,
+ <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/ref_african_crops_kenya_02_labels>,
+ <Link rel=mlhub:training-dataset target=https://mlhub.earth/data/ref_african_crops_kenya_02>]
     >>> # you can access rest of properties as a dict
     >>> first_model.properties.keys()
-    dict_keys(['title', 'license', 'sci:doi', 'datetime', 'providers', 'description', 'end_datetime', 'sci:citation', 'ml-model:type', 'start_datetime', 'sci:publications', 'ml-model:architecture', 'ml-model:prediction_type', 'ml-model:learning_approach'])
+    dict_keys(['title', 'license', 'sci:doi', 'datetime', 'providers', 'description', 'end_datetime', 'sci:citation', 'ml-model:type', 'start_datetime', 'sci:publications', 'ml-model:training-os', 'ml-model:architecture', 'ml-model:prediction_type', 'ml-model:learning_approach', 'ml-model:training-processor-type'])
 
 Low-level Client
 ----------------
@@ -65,9 +68,9 @@ can use the low-level :func:`~radiant_mlhub.client.list_models` function to work
     >>> first_model.keys()
     dict_keys(['id', 'bbox', 'type', 'links', 'assets', 'geometry', 'collection', 'properties', 'stac_version', 'stac_extensions'])
     >>> first_model['id']
-    'model-cyclone-wind-estimation-torchgeo-v1'
+    'model-cv4a-crop-detection-v1'
     >>> first_model['properties'].keys()
-    dict_keys(['title', 'license', 'sci:doi', 'datetime', 'providers', 'description', 'end_datetime', 'sci:citation', 'ml-model:type', 'start_datetime', 'sci:publications', 'ml-model:architecture', 'ml-model:prediction_type', 'ml-model:learning_approach'])
+    dict_keys(['title', 'license', 'sci:doi', 'datetime', 'providers', 'description', 'end_datetime', 'sci:citation', 'ml-model:type', 'start_datetime', 'sci:publications', 'ml-model:training-os', 'ml-model:architecture', 'ml-model:prediction_type', 'ml-model:learning_approach', 'ml-model:training-processor-type'])
 
 Fetching Model Metadata
 +++++++++++++++++++++++
@@ -94,4 +97,4 @@ method. This is the recommended way of fetching a model. This method returns a :
     >>> len(model.assets)
     2
     >>> len(model.links)
-    7
+    8

--- a/docs/source/ml_models.rst
+++ b/docs/source/ml_models.rst
@@ -38,20 +38,20 @@ You can fetch a model by ID using :meth:`MLModel.fetch <radiant_mlhub.models.MLM
 
     >>> model = MLModel.fetch('model-cyclone-wind-estimation-torchgeo-v1')
     >>> model.assets
-    {'inferencing-compose': <Asset href=https://raw.githubusercontent.com/RadiantMLHub/cyclone-model-torchgeo/main/inferencing.yml>,
- 'inferencing-checkpoint': <Asset href=https://zenodo.org/record/5773331/files/last.ckpt?download=1>}
+    .. {'inferencing-compose': <Asset href=https://raw.githubusercontent.com/RadiantMLHub/cyclone-model-torchgeo/main/inferencing.yml>,
+    .. 'inferencing-checkpoint': <Asset href=https://zenodo.org/record/5773331/files/last.ckpt?download=1>}
     >>> len(first_model.links)
     8
     >>> # print only the ml-model and mlhub related links
     >>> from pprint import pprint
     >>> pprint([ link for link in first_model.links if 'ml-model:' in link.rel or 'mlhub:' in link.rel])
-    [<Link rel=ml-model:inferencing-image target=docker://docker.io/radiantearth/crop-detection-dl:1>,
- <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/ref_african_crops_kenya_02_source>,
- <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/ref_african_crops_kenya_02_labels>,
- <Link rel=mlhub:training-dataset target=https://mlhub.earth/data/ref_african_crops_kenya_02>]
+    .. [<Link rel=ml-model:inferencing-image target=docker://docker.io/radiantearth/crop-detection-dl:1>,
+    .. <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/ref_african_crops_kenya_02_source>,
+    .. <Link rel=ml-model:train-data target=https://api.radiant.earth/mlhub/v1/collections/ref_african_crops_kenya_02_labels>,
+    .. <Link rel=mlhub:training-dataset target=https://mlhub.earth/data/ref_african_crops_kenya_02>]
     >>> # you can access rest of properties as a dict
     >>> first_model.properties.keys()
-    dict_keys(['title', 'license', 'sci:doi', 'datetime', 'providers', 'description', 'end_datetime', 'sci:citation', 'ml-model:type', 'start_datetime', 'sci:publications', 'ml-model:training-os', 'ml-model:architecture', 'ml-model:prediction_type', 'ml-model:learning_approach', 'ml-model:training-processor-type'])
+    .. dict_keys(['title', 'license', 'sci:doi', 'datetime', 'providers', 'description', 'end_datetime', 'sci:citation', 'ml-model:type', 'start_datetime', 'sci:publications', 'ml-model:training-os', 'ml-model:architecture', 'ml-model:prediction_type', 'ml-model:learning_approach', 'ml-model:training-processor-type'])
 
 Low-level Client
 ----------------


### PR DESCRIPTION
## Proposed Changes

While going through the `radiant_mlhub` readthedocs, I noticed a number of spots where functions, links, or outputs were outdated. 
* **Getting Started Section:** Broken link in [Getting Started — radiant_mlhub 0.5.1 documentation](https://radiant-mlhub.readthedocs.io/en/latest/getting_started.html#work-with-dataset-collections) where it links for “[STAC Label Extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/label)” under “Work with Dataset Collections”
--> correct link: [GitHub - stac-extensions/label: Label extension](https://github.com/stac-extensions/label) 

* **Collections Section:**  `ref_landcovernet_v1_source` (appears 3 times) name change -- no longer 1 `landcovernet` -> I chose to change the example to `umd_mali_crop_type` because this dataset only has one source and one label collection, so the explanation can be simple. (source: `umd_mali_crop_type_source`; labels: `umd_mali_crop_type_labels`) 

* **Collections Section**: `update download_archive` to `download_collection_archive` (this function name was changed a few version back, but changing the name in the readthedocs was missed

* **ML Models Section:** fixed variable typo `mode.assets` -> `model.assets`

* **ML Models Section:** I reran the notebook to get the current outputs (model order and info has changed since the notebook was last ran) 

Please let me know what of the checklist is needed by me for this and I will do it! 

## Checklist

- [x] I have updated/added any relevant documentation
- [x] ~I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.~ (N/A)
- [x] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

*Please link to any issues that this PR relates to.*