### PR TITLE
Add MLHUB_CI check to pytest workaround for vcry.py usage.

### DIFF
--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -634,7 +634,7 @@ class CatalogDownloader():
 
         self._finalize_db()
 
-        if 'PYTEST_CURRENT_TEST' in os.environ:
+        if 'PYTEST_CURRENT_TEST' in os.environ and 'MLHUB_CI' in os.environ:
             # vcr.py does not work multithreading `requests`, so bail out here
             # and consider it a 'dry run'.
             return

--- a/radiant_mlhub/retry_config.py
+++ b/radiant_mlhub/retry_config.py
@@ -11,7 +11,7 @@ def config() -> Optional[Retry]:
 
     `0.2 * (2 ** (10 - 1)) = 102.4 seconds`
     """
-    if 'PYTEST_CURRENT_TEST' in os.environ:
+    if 'PYTEST_CURRENT_TEST' in os.environ and 'MLHUB_CI' in os.environ:
         return None
 
     return Retry(


### PR DESCRIPTION
Fixes #148.

## Proposed Changes

* Fix bug where user cannot run the Dataset.download() feature in a pytest unit test.

## Checklist

- [ ] I have updated/added any relevant documentation
- [ ] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [ ] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

#148 