### PR TITLE
removing common_metadata variable and modifying datetime filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove the outdated reference to a common_metadata asset level STAC catalog property and modify variable assignment to properly collect the start_datetime and end_datetime properties from each asset. ([155](https://github.com/radiantearth/radiant-mlhub/pull/155))
+
 ### Changed
 
 ### Fixed

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from io import TextIOWrapper
 from logging import getLogger
 from pathlib import Path
-from tokenize import single_quoted
 from typing import Callable, Dict, List, Optional, Tuple, Union, Any, Set
 from urllib.parse import urlparse
 from dateutil.parser import parse as date_parser
@@ -224,7 +223,6 @@ class CatalogDownloader():
             item_id = stac_item['id']
             assets = stac_item['assets']
             props = stac_item['properties']
-            #common_meta = props.get('common_metadata', dict())
             datetime = props.get('datetime')
             bbox = stac_item.get('bbox', None)
             geometry = stac_item.get('geometry', None)


### PR DESCRIPTION
## Proposed Changes

* Remove the outdated reference to a `common_metadata` asset level STAC catalog property
* Modify variable assignment to properly collect the `start_datetime` and `end_datetime` properties from each asset

## Checklist

- [ ] I have updated/added any relevant documentation
- [ ] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions.
- [ ] Added changes to the [CHANGELOG](https://github.com/radiantearth/radiant-mlhub/blob/dev/CHANGELOG.md) (*or* a 
  CHANGELOG entry is not required)

## Related Issue(s)

*Please link to any issues that this PR relates to.*