### PR TITLE
Add MLHUB_CI check to pytest workaround circuiting code.

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -64,6 +64,7 @@ jobs:
           # some unit tests require an API_KEY env var, however it will not be used
           # because VCR.py responses were already recorded.
           MLHUB_API_KEY: 'required_but_not_used'
+          MLHUB_CI: 'true'
         run: |
           pip install .
           pytest --record-mode once --block-network

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -640,7 +640,7 @@ class CatalogDownloader():
 
         self._finalize_db()
 
-        if 'PYTEST_CURRENT_TEST' in os.environ:
+        if 'PYTEST_CURRENT_TEST' in os.environ and 'MLHUB_CI' in os.environ:
             # vcr.py does not work multithreading `requests`, so bail out here
             # and consider it a 'dry run'.
             return

--- a/radiant_mlhub/retry_config.py
+++ b/radiant_mlhub/retry_config.py
@@ -11,7 +11,7 @@ def config() -> Optional[Retry]:
 
     `0.2 * (2 ** (10 - 1)) = 102.4 seconds`
     """
-    if 'PYTEST_CURRENT_TEST' in os.environ:
+    if 'PYTEST_CURRENT_TEST' in os.environ and 'MLHUB_CI' in os.environ:
         return None
 
     return Retry(


### PR DESCRIPTION
Fixes #148.

## Proposed Changes

* Add MLHUB_CI check to pytest workaround circuiting code. This enables the radiant_mlhub python client to work if the user is calling it from their own pytest environment.

## Checklist

- [x] I have updated/added any relevant documentation (N/A)
- [x] I have updated any unit tests affected by these changes and/or added unit tests to cover any 
  additions. (N/A)
- [x]  CHANGELOG entry is not required.

## Related Issue(s)

*Please link to any issues that this PR relates to.*