### PR TITLE
Optimizations to catalog_downloader.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,3 +14,4 @@ exclude =
     build
 max-line-length = 140
 per-file-ignores = __init__.py:F401
+enable-extensions = G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Performance improvements to Dataset.download() ([182](https://github.com/radiantearth/radiant-mlhub/pull/182))
+- Enable INFO level logging by default in Dataset.download() ([182](https://github.com/radiantearth/radiant-mlhub/pull/182))
+
 ### Fixed
 
 ### Deprecated
 
 ### Developer
+
+- Add flake8-logging-format package ([182](https://github.com/radiantearth/radiant-mlhub/pull/182))
 
 ## [v0.5.3]
 

--- a/docs/source/api/radiant_mlhub.client.rst
+++ b/docs/source/api/radiant_mlhub.client.rst
@@ -28,6 +28,14 @@ radiant\_mlhub.client.datasets module
    :undoc-members:
    :show-inheritance:
 
+radiant\_mlhub.client.datetime\_utils module
+--------------------------------------------
+
+.. automodule:: radiant_mlhub.client.datetime_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 radiant\_mlhub.client.ml\_models module
 ---------------------------------------
 

--- a/docs/source/api/radiant_mlhub.rst
+++ b/docs/source/api/radiant_mlhub.rst
@@ -29,6 +29,14 @@ radiant\_mlhub.if\_exists module
    :undoc-members:
    :show-inheritance:
 
+radiant\_mlhub.retry\_config module
+-----------------------------------
+
+.. automodule:: radiant_mlhub.retry_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 radiant\_mlhub.session module
 -----------------------------
 

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -204,10 +204,13 @@ The output directory is the current working directory (by default).
     >>> print(nasa_marine_debris)
     nasa_marine_debris: Marine Debris Dataset for Object Detection in Planetscope Imagery
     >>> nasa_marine_debris.download()
-    nasa_marine_debris: fetch stac catalog: 258KB [00:00, 75252.46KB/s]                                                     
-    unarchive nasa_marine_debris.tar.gz: 100%|████████████████████████████████████| 2830/2830 [00:00<00:00, 14185.00it/s]
-    download assets: 100%|█████████████████████████████████████████████████████████████| 2825/2825 [00:19<00:00, 145.36it/s]
-
+    nasa_marine_debris: fetch stac catalog: 258KB [00:00, 412.53KB/s]
+    INFO:radiant_mlhub.client.catalog_downloader:unarchive nasa_marine_debris.tar.gz ...
+    unarchive nasa_marine_debris.tar.gz: 100%|████████████████████| 2830/2830 [00:00<00:00, 5772.09it/s]
+    INFO:radiant_mlhub.client.catalog_downloader:create stac asset list (please wait) ...
+    INFO:radiant_mlhub.client.catalog_downloader:2825 unique assets in stac catalog.
+    download assets: 100%|██████████████████████| 2825/2825 [03:27<00:00, 13.62it/s]
+    INFO:radiant_mlhub.client.catalog_downloader:assets saved to nasa_marine_debris
 
 Download STAC Catalog Archive Only
 ----------------------------------
@@ -227,20 +230,25 @@ the assets just pass the ``catalog_only`` option to the download method:
 Logging
 -------
 
-The Python logging module can be used to control the verbosity of the download. Turn in INFO or DEBUG messages to see additional messages:
+The [Python logging module](https://docs.python.org/3/howto/logging.html) can
+be used to control the verbosity of the downloader. The default log level is
+INFO.
+
+* Turn on WARNING level to see fewer log messages.
+* Set DEBUG level to see more messages. This includes verbose HTTP-level log messages.
 
 .. code-block:: python
 
     >>> import logging
-    >>> logging.basicConfig(level=logging.INFO)
+    >>> logging.basicConfig(level=logging.DEBUG)
     >>> nasa_marine_debris.download()
-    nasa_marine_debris: fetch stac catalog: 258KB [00:00, 34940.12KB/s]                                                     
-    INFO:radiant_mlhub.client.catalog_downloader:unarchive nasa_marine_debris.tar.gz...
-    unarchive nasa_marine_debris.tar.gz: 100%|████████████████████████████████████| 2830/2830 [00:00<00:00, 14191.09it/s]
-    INFO:radiant_mlhub.client.catalog_downloader:create stac asset list...
-    INFO:radiant_mlhub.client.catalog_downloader:2825 unique assets in stac catalog.
-    download assets: 100%|█████████████████████████████████████████████████████████████| 2825/2825 [00:18<00:00, 152.37it/s]
-    INFO:radiant_mlhub.client.catalog_downloader:assets saved to /home/user/nasa_marine_debris
+    ...
+    DEBUG:radiant_mlhub.client.catalog_downloader:(thread id: 123145809592320) https://radiantearth.blob.core.windows.net/mlhub/nasa-marine-debris/labels/20170326_153234_0e26_17069-29758-16.npy -> .../nasa_marine_debris/nasa_marine_debris_labels/nasa_marine_debris_labels_20170326_153234_0e26_17069-29758-16/pixel_bounds.npy
+    ...
+    DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): radiantearth.blob.core.windows.net:443
+    DEBUG:urllib3.connectionpool:https://radiantearth.blob.core.windows.net:443 "HEAD /mlhub/nasa-marine-debris/labels/20181031_095925_103b_32713-31765-16.npy HTTP/1.1" 200 0
+    ...
+    (omitted many log messages here)
 
 Output Directory
 ----------------

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -230,7 +230,7 @@ the assets just pass the ``catalog_only`` option to the download method:
 Logging
 -------
 
-The [Python logging module](https://docs.python.org/3/howto/logging.html) can
+The `Python logging module <https://docs.python.org/3/howto/logging.html>`_ can
 be used to control the verbosity of the downloader. The default log level is
 INFO.
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -170,9 +170,13 @@ is relatively small in size. The downloader can also scale up to the largest dat
     >>> print(dataset.estimated_dataset_size)  # OK the total dataset assets are ~77MB
     77207762
     >>> dataset.download()
-    nasa_marine_debris: fetch stac catalog: 258KB [00:00, 404.83KB/s]                                                                                                        
-    unarchive nasa_marine_debris.tar.gz: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 2830/2830 [00:00<00:00, 4744.75it/s]
-    download assets: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2825/2825 [03:48<00:00, 12.36it/s]
+    nasa_marine_debris: fetch stac catalog: 258KB [00:00, 412.53KB/s]
+    INFO:radiant_mlhub.client.catalog_downloader:unarchive nasa_marine_debris.tar.gz ...
+    unarchive nasa_marine_debris.tar.gz: 100%|████████████████████| 2830/2830 [00:00<00:00, 5772.09it/s]
+    INFO:radiant_mlhub.client.catalog_downloader:create stac asset list (please wait) ...
+    INFO:radiant_mlhub.client.catalog_downloader:2825 unique assets in stac catalog.
+    download assets: 100%|██████████████████████| 2825/2825 [03:27<00:00, 13.62it/s]
+    INFO:radiant_mlhub.client.catalog_downloader:assets saved to nasa_marine_debris
 
 The :meth:`Dataset.download <radiant_mlhub.models.Dataset.download>` method
 saves the STAC catalog and assets into your current working directory (by default).

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -157,7 +157,7 @@ class CatalogDownloader():
         """
         c = self.config
         msg = f'unarchive {self.catalog_file.name}'
-        log.info('{info} ...', extra=dict(info=msg))
+        log.info('%s ...', msg)
         with tarfile.open(self.catalog_file, 'r:gz') as archive:
             if self.config.if_exists == DownloadIfExistsOpts.overwrite:
                 archive.extractall(path=c.output_dir)
@@ -286,7 +286,7 @@ class CatalogDownloader():
             # early out if there is a collection_filter but collection_id is not
             # a member of the collection_filter.
             if self.config.collection_filter and collection_id not in self.config.collection_filter:
-                log.warning('skipping collection {collection_id}', extra=dict(collection_id=collection_id))
+                log.warning('skipping collection %s', collection_id)
                 return
 
             assets = stac_collection.get('assets', None)
@@ -328,7 +328,7 @@ class CatalogDownloader():
                     _handle_collection(stac_item)
                 else:
                     _handle_item(stac_item)
-        log.info('{count} unique assets in stac catalog.', extra=dict(count=self._fetch_unfiltered_count()))
+        log.info('%s unique assets in stac catalog.', self._fetch_unfiltered_count())
 
     def _filter_collections_step(self) -> None:
         """
@@ -387,7 +387,7 @@ class CatalogDownloader():
             raise RuntimeError(
                 f'after filtering collections_ids and asset keys, zero assets to download. filter: {filter}'
             )
-        log.info('{count} assets after collection filter.', extra=dict(count=total_asset_ct))
+        log.info('%s assets after collection filter.', total_asset_ct)
 
     def _filter_bbox_step(self) -> None:
         """
@@ -431,7 +431,7 @@ class CatalogDownloader():
             for row_tuple in rows:
                 (row_id, item_id, bbox_json) = row_tuple
                 if not bbox_json:
-                    log.warning('item missing bbox: {item_id}', extra=dict(item_id=item_id))
+                    log.warning('item missing bbox: %s', item_id)
                     continue
                 hit = item_bbox_cache.get(item_id, None)
                 if hit is None:
@@ -449,7 +449,7 @@ class CatalogDownloader():
             raise RuntimeError(
                 f'after filtering by bounding box, zero assets to download. filter: {filter}'
             )
-        log.info('{total_asset_ct} assets after bounding box filter.', extra=dict(total_asset_ct=total_asset_ct))
+        log.info('%s assets after bounding box filter.', total_asset_ct)
 
     def _filter_intersects_step(self) -> None:
         """
@@ -495,7 +495,7 @@ class CatalogDownloader():
             for row_tuple in rows:
                 (row_id, item_id, bbox_json) = row_tuple
                 if not bbox_json:
-                    log.warning('item missing bbox: {item_id}', extra=dict(item_id=item_id))
+                    log.warning('item missing bbox: %s', item_id)
                     continue
                 hit = item_intersects_cache.get(item_id, None)
                 if hit is None:
@@ -513,7 +513,7 @@ class CatalogDownloader():
             raise RuntimeError(
                 f'after filtering by intersects, zero assets to download. filter: {filter}'
             )
-        log.info('{total_asset_ct} assets after intersects filter.', extra=dict(total_asset_ct=total_asset_ct))
+        log.info('%s assets after intersects filter.', total_asset_ct)
 
     def _filter_temporal_step(self) -> None:
         """
@@ -568,7 +568,7 @@ class CatalogDownloader():
                     end = date_parser(end_datetime)
                     if not start or not end:
                         # cannot process date range, just skip forward and log a warning
-                        log.warning('cannot compare to missing date range for: {item_id}', extra=dict(item_id=item_id))
+                        log.warning('cannot compare to missing date range for: %s', item_id)
                         continue
                     if isinstance(q, tuple):
                         filtered = not datetime_utils.range_to_range_check((start, end), q)
@@ -584,7 +584,7 @@ class CatalogDownloader():
             raise RuntimeError(
               f'after filtering by temporal query, zero assets to download. filter: {filter}'
             )
-        log.info('{total_asset_ct} assets after temporal filter.', extra=dict(total_asset_ct=total_asset_ct))
+        log.info('%s assets after temporal filter.', total_asset_ct)
 
     def _asset_download_step(self) -> None:
         """
@@ -605,12 +605,11 @@ class CatalogDownloader():
             https://{bucket_name}.s3.amazonaws.com .
             """
             log.debug(
-                '(thread id: {thread_id}) {asset_url} -> {out_file}',
-                extra=dict(
-                    thread_id=threading.get_ident(),
-                    asset_url=asset_url,
-                    out_file=out_file,
-                ))
+                '(thread id: %s) %s -> %s',
+                threading.get_ident(),
+                asset_url,
+                out_file,
+            )
             if not out_file.parent.exists():
                 out_file.parent.mkdir(exist_ok=True, parents=True)
             if 's3://' in asset_url:
@@ -789,6 +788,6 @@ class CatalogDownloader():
             raise IOError(msg)
 
         if c.catalog_only:
-            log.info('catalog saved to {work_dir}', extra=dict(work_dir=self.work_dir))
+            log.info('catalog saved to %s', self.work_dir)
         else:
-            log.info('assets saved to {self.asset_dir}', extra=dict(asset_dir=self.asset_dir))
+            log.info('assets saved to %s', self.asset_dir)

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -703,7 +703,10 @@ class CatalogDownloader():
                         asset_rec.get('asset_key'),
                         asset_rec.get('asset_url'),
                     ])
-                    log.exception(e)  # noqa: G200
+                    # write log message with exception info, but don't break out of
+                    # thread pool executor.
+                    err_msg = str(e)
+                    log.exception(err_msg)
 
     def _init_db(self) -> None:
         db_path = self.asset_dir / 'mlhub_stac_assets.db'

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -84,6 +84,7 @@ class AssetRecord(TypedDict):
 class CatalogDownloader():
 
     config: CatalogDownloaderConfig
+    err_writer: Any
     err_report: TextIOWrapper
     err_report_path: Path
     catalog_file: Path
@@ -320,7 +321,7 @@ class CatalogDownloader():
             p = Path(json_src)
             if p.name == 'catalog.json':
                 continue
-            with open(json_src) as json_fh:
+            with open(json_src, encoding='utf-8') as json_fh:
                 stac_item = json.load(json_fh)
                 stac_type = stac_item.get('type', None)
                 if p.name == 'collection.json' or stac_type == 'Collection':
@@ -568,7 +569,7 @@ class CatalogDownloader():
                     if not start or not end:
                         # cannot process date range, just skip forward and log a warning
                         log.warning('cannot compare to missing date range for: {item_id}', extra=dict(item_id=item_id))
-                        next
+                        continue
                     if isinstance(q, tuple):
                         filtered = not datetime_utils.range_to_range_check((start, end), q)
                     else:
@@ -743,7 +744,7 @@ class CatalogDownloader():
         Create and run functions for each processing step.
         """
         c = self.config
-        self.err_report = open(self.err_report_path, 'w')
+        self.err_report = open(self.err_report_path, 'w', encoding='utf-8')
         self.err_writer = csv.writer(self.err_report, quoting=csv.QUOTE_MINIMAL)
 
         steps: List[Callable[[], None]] = []

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -201,8 +201,7 @@ class CatalogDownloader():
             elif '.csv' in url:
                 ext = 'csv'
             else:
-                print(f'unknown ext {url}')
-                # parse the url and extract the path -> file sufix
+                # parse the url and extract the path -> file suffix (slow)
                 ext = Path(str(urlparse(rec['asset_url']).path)).suffix
             base_path = self.asset_dir / rec['collection_id']  # type: ignore
             asset_filename = f"{rec['asset_key']}{ext}"

--- a/radiant_mlhub/client/catalog_downloader.py
+++ b/radiant_mlhub/client/catalog_downloader.py
@@ -281,6 +281,13 @@ class CatalogDownloader():
 
         def _handle_collection(stac_collection: JsonDict) -> None:
             collection_id = stac_collection['id']
+
+            # early out if there is a collection_filter but collection_id is not
+            # a member of the collection_filter.
+            if self.config.collection_filter and collection_id not in self.config.collection_filter:
+                log.warning('skipping collection {collection_id}', extra=dict(collection_id=collection_id))
+                return
+
             assets = stac_collection.get('assets', None)
             if assets is None:
                 return

--- a/radiant_mlhub/client/resumable_downloader.py
+++ b/radiant_mlhub/client/resumable_downloader.py
@@ -78,11 +78,11 @@ class ResumableDownloader():
         self.out_file.parent.mkdir(exist_ok=True, parents=True)
         if self.out_file.exists():
             if self.if_exists == DownloadIfExistsOpts.skip:
-                log.debug(f'{self.out_file.resolve()} -> skip')
+                log.debug('{path} -> skip', extra=dict(path=self.out_file.resolve()))
                 return
             elif self.if_exists == DownloadIfExistsOpts.overwrite:
                 self.out_file.unlink()
-                log.debug(f'{self.out_file.resolve()} -> overwrite')
+                log.debug('{path} -> overwrite', extra=dict(path=self.out_file.resolve()))
             elif self.if_exists == DownloadIfExistsOpts.resume:
                 # make HEAD request to get content-length (detect whether to resume)
                 resp = self.session.head(self.url, allow_redirects=True)
@@ -92,7 +92,7 @@ class ResumableDownloader():
                 assert size <= content_len, 'unexpected asset size on filesystem'
                 if size == content_len:
                     return  # nothing to resume
-                log.debug(f'{self.out_file.resolve()} -> resume')
+                log.debug('{path} -> resume', extra=dict(path=self.out_file.resolve()))
 
         with open(self.out_file, mode='ab') as fh:
             req_headers = self.session.headers.copy()

--- a/radiant_mlhub/client/resumable_downloader.py
+++ b/radiant_mlhub/client/resumable_downloader.py
@@ -78,11 +78,11 @@ class ResumableDownloader():
         self.out_file.parent.mkdir(exist_ok=True, parents=True)
         if self.out_file.exists():
             if self.if_exists == DownloadIfExistsOpts.skip:
-                log.debug('{path} -> skip', extra=dict(path=self.out_file.resolve()))
+                log.debug('%s -> skip', self.out_file)
                 return
             elif self.if_exists == DownloadIfExistsOpts.overwrite:
                 self.out_file.unlink()
-                log.debug('{path} -> overwrite', extra=dict(path=self.out_file.resolve()))
+                log.debug('%s -> overwrite', self.out_file)
             elif self.if_exists == DownloadIfExistsOpts.resume:
                 # make HEAD request to get content-length (detect whether to resume)
                 resp = self.session.head(self.url, allow_redirects=True)
@@ -92,7 +92,7 @@ class ResumableDownloader():
                 assert size <= content_len, 'unexpected asset size on filesystem'
                 if size == content_len:
                     return  # nothing to resume
-                log.debug('{path} -> resume', extra=dict(path=self.out_file.resolve()))
+                log.debug('%s -> resume', self.out_file)
 
         with open(self.out_file, mode='ab') as fh:
             req_headers = self.session.headers.copy()

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,4 +1,5 @@
 flake8==5.0.4
+flake8-logging-format==0.8.1
 isort==5.10.1
 mypy==0.982
 pytest-click==1.1.0


### PR DESCRIPTION
# Proposed Changes

Improves logging user experience, and removes couple of bottlenecks found in python profiling of dataset downloader.
Speeds up _create_asset_list_step by about 25%. In the case of user providing `collection_filter` to downloader, speedup should be more significant.

* Remove `pydantic` data model from inner loop and use `TypedDict` instead. 
* Avoid calling `urlparse` for common asset types.
* Early out when processing collections, and a collection_filter is given by user. This should provide a significant speed-up if the user is just slicing into a large dataset with specific collection ids + asset keys.
* Call `logging.basicConfig(level=logging.INFO)` in the CatalogDownloader. This results in INFO messages always being seen by the user, unless they have already setup logging with a different level. Therefore, more feedback about the work-in-progress is given.
* Linting/Optimization: Pylint warns about all the format strings being used in logging.  Change all logging calls to use the recommended formatting for calls to logging. 
* Linting configuration. Setup flake8 to use this plugin which should detect the above problem re: format strings sent to logging. https://pypi.org/project/flake8-logging-format/
* Fix various `pylint` errors and warnings. (for some reason `flake8` did not find all these).
* Fix error: `next` keyword should be `continue`, not next. Interesting that pylint catches this, but flake8 does not. This seems like an edge case which is not covered in our unit tests (but also should never occur in valid stac items, in any case).

## Checklist for Submitter

* [x] Updated/added any relevant documentation.
* [x] Added changes/fixes to the [Changelog](CHANGELOG.md).
* [x] N/A Updated any unit tests affected by these changes and/or added unit tests to cover any additions.
* [x] N/A Added changes to the [Architecture Decision Records (ADR)](docs/adr).

## Related Issues

N/A

