### PR TITLE
Add Python 3.11 to GitHub 'Unit Tests' workflow.

### DIFF
--- a/.github/workflows/run-unit-tests-vs-staging.yml
+++ b/.github/workflows/run-unit-tests-vs-staging.yml
@@ -13,13 +13,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
         os:
           - ubuntu-latest
-          - macos-latest
-          - windows-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -37,6 +37,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         os:
           - ubuntu-latest
           - macos-latest
@@ -81,6 +82,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
# Proposed Changes

* Add Python 3.11 to GitHub 'Unit Tests' workflow.
* Slim down the GitHub workflow for live testing vs staging API. (does not need to run on full matrix of OS * python versions).

## Checklist for Submitter

* [x] N/A Updated/added any relevant documentation.
* [x] N/A Added changes/fixes to the [Changelog](/CHANGELOG.md).
* [x] N/A Updated any unit tests affected by these changes and/or added unit tests to cover any additions, or this is N/A.
* [x] N/A Added changes to the [Architecture Decision Records (ADR)](/docs/adr), or this is N/A.

## Related Issues

-
