### PR TITLE
Dependencies: add support for shapely 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for shapely 2
+
 ### Removed
 
 ### Changed
@@ -244,7 +246,7 @@ Unreleased version.
 
 ## [v0.1.0]
 
-First working `alpha` release of the Radiant MLHub Python client. 
+First working `alpha` release of the Radiant MLHub Python client.
 
 Includes support for:
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         'pystac~=1.4.0',
         'python-dateutil~=2.8.2',
         'requests~=2.27.0',
-        'shapely~=1.8.0',
+        'shapely>=1.8,<3',
         'tqdm~=4.64.0',
         'urllib3~=1.26.11'
     ],


### PR DESCRIPTION
# Proposed Changes

This PR adds support for shapely 2. As far as I can tell, I don't see any usage that requires shapely 1, but hopefully the unit tests will confirm this.

## Checklist for Submitter

* [x] Updated/added any relevant documentation.
* [x] Added changes/fixes to the [Changelog](/CHANGELOG.md).
* [x] Updated any unit tests affected by these changes and/or added unit tests to cover any additions, or this is N/A.
* [x] Added changes to the [Architecture Decision Records (ADR)](/docs/adr), or this is N/A.

## Related Issues

We are trying to [update TorchGeo](https://github.com/microsoft/torchgeo/pull/1102) to support radiant-mlhub 0.5+ but noticed that we were unable to test the latest versions of both radiant-mlhub and shapely due to an overly strict dependency pin.